### PR TITLE
Add Type Checker Output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "concrete_ast"
+version = "0.1.0"
+dependencies = [
+ "ast",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 
-members = [
-    "rust/ast",
-    "rust/parser",
-]
+members = ["rust/concrete_ast", "rust/ast", "rust/parser"]
 
 [toolchain]
 channel = "1.66.0"

--- a/rust/concrete_ast/Cargo.toml
+++ b/rust/concrete_ast/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "concrete_ast"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ast = { path = "../ast" }

--- a/rust/concrete_ast/src/concrete_types.rs
+++ b/rust/concrete_ast/src/concrete_types.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrimitiveType {
+    Num,
+    Str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteFunctionType {
+    /// Types of the arguments of a function, in order.
+    /// If a function does not take any arguments, then the vec is empty.
+    pub argument_types: Vec<ConcreteType>,
+    /// return_type = None means that the function does not return a value.
+    pub return_type: Option<ConcreteType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteTagUnionType {
+    /// Map the name of a tag to an array of the types of its contained values.
+    /// Tag with no contents maps to empty vec.
+    pub tag_types: HashMap<String, Vec<ConcreteType>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteListType {
+    pub element_type: ConcreteType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteRecordType {
+    /// Map field name to type of that field.
+    pub field_types: HashMap<String, ConcreteType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConcreteType {
+    Primitive(PrimitiveType),
+    Function(Box<ConcreteFunctionType>),
+    TagUnion(Box<ConcreteTagUnionType>),
+    List(Box<ConcreteListType>),
+    Record(Box<ConcreteRecordType>),
+}

--- a/rust/concrete_ast/src/lib.rs
+++ b/rust/concrete_ast/src/lib.rs
@@ -1,0 +1,2 @@
+mod concrete_types;
+mod nodes;

--- a/rust/concrete_ast/src/nodes.rs
+++ b/rust/concrete_ast/src/nodes.rs
@@ -1,0 +1,92 @@
+use crate::concrete_types::ConcreteType;
+use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteBinaryOperatorExpression {
+    pub concrete_type: ConcreteType,
+    pub symbol: BinaryOperatorSymbol,
+    pub left_child: ConcreteExpression,
+    pub right_child: ConcreteExpression,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteBlockExpression {
+    pub concrete_type: ConcreteType,
+    pub contents: Vec<ConcreteExpression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteFunctionExpression {
+    pub concrete_type: ConcreteType,
+    pub argument_names: Vec<String>,
+    pub body: ConcreteExpression,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteIdentifierExpression {
+    pub concrete_type: ConcreteType,
+    pub name: String,
+    pub is_disregarded: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteIfExpression {
+    pub concrete_type: ConcreteType,
+    pub condition: ConcreteExpression,
+    pub path_if_true: ConcreteExpression,
+    pub path_if_false: Option<ConcreteExpression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteIntegerExpression {
+    pub concrete_type: ConcreteType,
+    pub value: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteListExpression {
+    pub concrete_type: ConcreteType,
+    pub contents: Vec<ConcreteExpression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteRecordExpression {
+    pub concrete_type: ConcreteType,
+    pub contents: HashMap<String, ConcreteExpression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteStringLiteralExpression {
+    pub concrete_type: ConcreteType,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteTagExpression {
+    pub concrete_type: ConcreteType,
+    pub name: String,
+    pub contents: Vec<ConcreteExpression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteUnaryOperatorExpression {
+    pub concrete_type: ConcreteType,
+    pub symbol: UnaryOperatorSymbol,
+    pub child: ConcreteExpression,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ConcreteExpression {
+    BinaryOperator(Box<ConcreteBinaryOperatorExpression>),
+    Block(Box<ConcreteBlockExpression>),
+    Function(Box<ConcreteFunctionExpression>),
+    Identifier(Box<ConcreteIdentifierExpression>),
+    If(Box<ConcreteIfExpression>),
+    Integer(Box<ConcreteIntegerExpression>),
+    List(Box<ConcreteListExpression>),
+    Record(Box<ConcreteRecordExpression>),
+    StringLiteral(Box<ConcreteStringLiteralExpression>),
+    Tag(Box<ConcreteTagExpression>),
+    UnaryOperator(Box<ConcreteUnaryOperatorExpression>),
+}


### PR DESCRIPTION
A possible exchange format from the type checker to the compiler backed. Does not implement entire grammar.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
