### PR TITLE
Prepend record set method with a $

### DIFF
--- a/packages/std/prelude/record.js
+++ b/packages/std/prelude/record.js
@@ -19,7 +19,7 @@ Object.assign(Object.prototype, {
     /* let theodore = person.$set("name", "Theodore")
     /* ```
      */
-    set(key, value) {
+    $set(key, value) {
         return new this.constructor({ ...this.valueOf(), [key]: value })
     },
 })

--- a/packages/std/prelude/record.test.js
+++ b/packages/std/prelude/record.test.js
@@ -23,12 +23,12 @@ it("trait methods added to records should be available after cloning", () => {
 
 it("can set keys by their name", () => {
     const record = { a: 1, b: 2 }
-    const newRecord = record.set("a", 3)
+    const newRecord = record.$set("a", 3)
     expect(newRecord.a).toBe(3)
 })
 
 it("setting a key produces a new object", () => {
     const record = { a: 1, b: 2 }
-    const newRecord = record.set("a", 3)
+    const newRecord = record.$set("a", 3)
     expect(newRecord).not.toBe(record)
 })


### PR DESCRIPTION
Simply renamed the method to `$set` to remove any potential conflicts with any trait methods developers may write.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
