### PR TITLE
Add constraints, TypeSchema, and TypeSchemaSubstitutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,3 +70,11 @@ dependencies = [
  "ast",
  "nom",
 ]
+
+[[package]]
+name = "type_checker"
+version = "0.1.0"
+dependencies = [
+ "ast",
+ "concrete_ast",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 
-members = ["rust/concrete_ast", "rust/ast", "rust/parser", "rust/js_backend"]
+members = [
+    "rust/concrete_ast",
+    "rust/ast",
+    "rust/parser",
+    "rust/js_backend",
+    "rust/type_checker",
+]
 
 [toolchain]
 channel = "1.66.0"

--- a/rust/type_checker/Cargo.toml
+++ b/rust/type_checker/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "type_checker"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ast = { path = "../ast" }
+concrete_ast = { path = "../concrete_ast" }

--- a/rust/type_checker/src/constraints.rs
+++ b/rust/type_checker/src/constraints.rs
@@ -1,0 +1,39 @@
+use crate::GenericTypeId;
+use concrete_ast::ConcreteType;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Constrain that a generic type be a tag union with a tag named `tag_name`,
+/// the contents of which have the types of `tag_contents_types`.
+pub struct SubTagConstraint {
+    pub tag_name: String,
+    pub tag_content_types: Vec<GenericTypeId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Constrain that a generic type be a record with a field named `field_name`,
+/// the type of which is `field_type`.
+pub struct HasFieldConstraint {
+    pub field_name: String,
+    pub field_type: GenericTypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Constrain that a generic type be a record with a method named `method_name`,
+/// the type of which is `method_type`.
+pub struct HasMethodConstraint {
+    pub method_name: String,
+    pub method_type: GenericTypeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Constraint {
+    /// Constrain that a generic type be equal to some concrete type.
+    EqualToConcrete(ConcreteType),
+    SubTag(SubTagConstraint),
+    HasField(HasFieldConstraint),
+    HasMethod(HasMethodConstraint),
+    /// Constrain that a generic type is a function with a given return type.
+    HasReturnType(GenericTypeId),
+    /// Constrain that a generic type is a function whose arguments have given types.
+    HasArgumentTypes(Vec<GenericTypeId>),
+}

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -1,0 +1,5 @@
+mod constraints;
+mod type_schema;
+mod type_schema_substitutions;
+
+type GenericTypeId = usize;

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -1,0 +1,25 @@
+use crate::{constraints::Constraint, GenericTypeId};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeSchema {
+    pub next_id: GenericTypeId,
+    pub constraints: HashMap<GenericTypeId, Vec<Constraint>>,
+    pub imports: HashMap<String, GenericTypeId>,
+}
+
+impl TypeSchema {
+    pub fn new() -> Self {
+        Self {
+            next_id: 0,
+            constraints: HashMap::new(),
+            imports: HashMap::new(),
+        }
+    }
+    /// Return an id which is unique in this `TypeSchema`.
+    pub fn make_id(&mut self) -> GenericTypeId {
+        let return_value = self.next_id;
+        self.next_id += 1;
+        return_value
+    }
+}

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -1,0 +1,422 @@
+use crate::{
+    constraints::{Constraint, HasFieldConstraint, HasMethodConstraint, SubTagConstraint},
+    type_schema::TypeSchema,
+    GenericTypeId,
+};
+use std::collections::HashMap;
+
+pub struct TypeSchemaSubstitutions {
+    /// Implement a disjoint set / union find data structure.
+    /// The mapping from key `x` to value `y` signifies that `y` is the parent of `x`.
+    /// If `x` is its own parent, then it is a root node of a set.
+    /// The id of a root node in a set is considered the canonical name of the every id in the set.
+    disjoint_set: Vec<GenericTypeId>,
+}
+
+impl TypeSchemaSubstitutions {
+    pub const fn new() -> Self {
+        Self {
+            disjoint_set: Vec::new(),
+        }
+    }
+    pub fn insert_new_id(&mut self, typ: GenericTypeId) {
+        while self.disjoint_set.len() <= typ {
+            self.disjoint_set.push(self.disjoint_set.len());
+        }
+    }
+    pub fn get_canonical_id(&mut self, typ: GenericTypeId) -> GenericTypeId {
+        match self.disjoint_set.get(typ) {
+            None => typ,
+            Some(parent_id_ref) => {
+                let parent_id = *parent_id_ref;
+                if parent_id == typ {
+                    typ
+                } else {
+                    let canonical_id = self.get_canonical_id(parent_id);
+                    self.disjoint_set[typ] = canonical_id;
+                    canonical_id
+                }
+            }
+        }
+    }
+    pub fn set_types_equal(&mut self, type_a: GenericTypeId, type_b: GenericTypeId) {
+        let canonical_a = self.get_canonical_id(type_a);
+        let canonical_b = self.get_canonical_id(type_b);
+        self.disjoint_set[canonical_a] = canonical_b;
+    }
+    fn apply_to_vec(&mut self, input: Vec<GenericTypeId>) -> Vec<GenericTypeId> {
+        input
+            .into_iter()
+            .map(|typ| self.get_canonical_id(typ))
+            .collect()
+    }
+    fn apply_to_constraint(&mut self, constraint: Constraint) -> Constraint {
+        match constraint {
+            Constraint::EqualToConcrete(x) => Constraint::EqualToConcrete(x),
+            Constraint::SubTag(sub_tag_constraint) => Constraint::SubTag(SubTagConstraint {
+                tag_name: sub_tag_constraint.tag_name,
+                tag_content_types: self.apply_to_vec(sub_tag_constraint.tag_content_types),
+            }),
+            Constraint::HasField(has_field_constraint) => {
+                Constraint::HasField(HasFieldConstraint {
+                    field_name: has_field_constraint.field_name,
+                    field_type: self.get_canonical_id(has_field_constraint.field_type),
+                })
+            }
+            Constraint::HasMethod(has_method_constraint) => {
+                Constraint::HasMethod(HasMethodConstraint {
+                    method_name: has_method_constraint.method_name,
+                    method_type: self.get_canonical_id(has_method_constraint.method_type),
+                })
+            }
+            Constraint::HasReturnType(return_type) => {
+                Constraint::HasReturnType(self.get_canonical_id(return_type))
+            }
+            Constraint::HasArgumentTypes(argument_types) => {
+                Constraint::HasArgumentTypes(self.apply_to_vec(argument_types))
+            }
+        }
+    }
+    fn apply_to_constraints_map(
+        &mut self,
+        input: HashMap<GenericTypeId, Vec<Constraint>>,
+    ) -> HashMap<GenericTypeId, Vec<Constraint>> {
+        let mut output: HashMap<GenericTypeId, Vec<Constraint>> = HashMap::new();
+        for (key, value) in input {
+            let canonical = self.get_canonical_id(key);
+            let mut new_constraints = value
+                .into_iter()
+                .map(|constraint| self.apply_to_constraint(constraint))
+                .collect();
+            match output.get_mut(&canonical) {
+                Some(output_vec) => output_vec.append(&mut new_constraints),
+                None => {
+                    output.insert(canonical, new_constraints);
+                }
+            }
+        }
+        output
+    }
+    fn apply_to_imports_map(
+        &mut self,
+        input: HashMap<String, GenericTypeId>,
+    ) -> HashMap<String, GenericTypeId> {
+        let mut output = HashMap::new();
+        for (key, value) in input {
+            output.insert(key, self.get_canonical_id(value));
+        }
+        output
+    }
+    pub fn apply_to_type_schema(&mut self, input: TypeSchema) -> TypeSchema {
+        TypeSchema {
+            next_id: input.next_id,
+            constraints: self.apply_to_constraints_map(input.constraints),
+            imports: self.apply_to_imports_map(input.imports),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn type_is_its_own_canonical_id() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        substitutions.insert_new_id(3);
+        assert_eq!(substitutions.get_canonical_id(3), 3);
+    }
+
+    #[test]
+    fn two_types_each_have_their_own_canonical_id() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        substitutions.insert_new_id(3);
+        substitutions.insert_new_id(5);
+        assert_eq!(substitutions.get_canonical_id(3), 3);
+        assert_eq!(substitutions.get_canonical_id(5), 5);
+    }
+
+    #[test]
+    fn when_two_types_are_made_equal_they_have_the_same_canonical_id() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        substitutions.insert_new_id(3);
+        substitutions.insert_new_id(5);
+        substitutions.set_types_equal(3, 5);
+        assert_eq!(
+            substitutions.get_canonical_id(3),
+            substitutions.get_canonical_id(5)
+        );
+    }
+
+    #[test]
+    fn equality_is_commutative() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        substitutions.insert_new_id(3);
+        substitutions.insert_new_id(5);
+        substitutions.insert_new_id(7);
+        substitutions.set_types_equal(3, 5);
+        substitutions.set_types_equal(5, 7);
+        assert_eq!(
+            substitutions.get_canonical_id(3),
+            substitutions.get_canonical_id(7)
+        );
+    }
+
+    #[test]
+    fn when_two_types_are_set_equal_other_types_still_have_a_different_canonical_id() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        substitutions.insert_new_id(3);
+        substitutions.insert_new_id(5);
+        substitutions.insert_new_id(7);
+        substitutions.set_types_equal(3, 5);
+        assert_ne!(
+            substitutions.get_canonical_id(3),
+            substitutions.get_canonical_id(7)
+        );
+        assert_ne!(
+            substitutions.get_canonical_id(5),
+            substitutions.get_canonical_id(7)
+        );
+    }
+
+    #[test]
+    fn apply_to_type_schema_replaces_all_instances_of_a_given_id_in_constraint_keys() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.constraints.insert(
+            type_a,
+            vec![Constraint::HasField(HasFieldConstraint {
+                field_name: "hello".to_owned(),
+                field_type: type_b,
+            })],
+        );
+        schema.constraints.insert(
+            type_b,
+            vec![Constraint::HasMethod(HasMethodConstraint {
+                method_name: "world".to_owned(),
+                method_type: type_c,
+            })],
+        );
+        schema
+            .constraints
+            .insert(type_c, vec![Constraint::HasReturnType(type_a)]);
+        substitutions.set_types_equal(type_a, type_b);
+        let new_schema = substitutions.apply_to_type_schema(schema);
+        assert_eq!(new_schema.constraints.len(), 2);
+        assert_eq!(
+            new_schema
+                .constraints
+                .get(&substitutions.get_canonical_id(type_a))
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            new_schema
+                .constraints
+                .get(&substitutions.get_canonical_id(type_b))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn apply_to_type_schema_does_not_replace_non_substituted_ids_in_constraint_keys() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.constraints.insert(
+            type_a,
+            vec![Constraint::HasField(HasFieldConstraint {
+                field_name: "hello".to_owned(),
+                field_type: type_b,
+            })],
+        );
+        schema.constraints.insert(
+            type_b,
+            vec![Constraint::HasMethod(HasMethodConstraint {
+                method_name: "world".to_owned(),
+                method_type: type_c,
+            })],
+        );
+        schema
+            .constraints
+            .insert(type_c, vec![Constraint::HasReturnType(type_a)]);
+        substitutions.set_types_equal(type_a, type_b);
+        let new_schema = substitutions.apply_to_type_schema(schema);
+        assert_eq!(
+            new_schema
+                .constraints
+                .get(&substitutions.get_canonical_id(type_c))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn apply_to_type_schema_replaces_all_instances_of_a_given_id_in_constraint_values() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.constraints.insert(
+            type_a,
+            vec![Constraint::HasField(HasFieldConstraint {
+                field_name: "hello".to_owned(),
+                field_type: type_b,
+            })],
+        );
+        schema.constraints.insert(
+            type_b,
+            vec![Constraint::HasMethod(HasMethodConstraint {
+                method_name: "world".to_owned(),
+                method_type: type_c,
+            })],
+        );
+        schema
+            .constraints
+            .insert(type_c, vec![Constraint::HasReturnType(type_a)]);
+        substitutions.set_types_equal(type_a, type_b);
+        let new_schema = substitutions.apply_to_type_schema(schema);
+        for (_, constraint_vec) in new_schema.constraints {
+            for constraint in constraint_vec {
+                match constraint {
+                    Constraint::HasField(has_field_constraint) => {
+                        assert_eq!(
+                            substitutions.get_canonical_id(has_field_constraint.field_type),
+                            substitutions.get_canonical_id(type_a)
+                        );
+                        assert_eq!(
+                            substitutions.get_canonical_id(has_field_constraint.field_type),
+                            substitutions.get_canonical_id(type_b)
+                        );
+                    }
+                    Constraint::HasReturnType(return_type) => {
+                        assert_eq!(
+                            substitutions.get_canonical_id(return_type),
+                            substitutions.get_canonical_id(type_a)
+                        );
+                        assert_eq!(
+                            substitutions.get_canonical_id(return_type),
+                            substitutions.get_canonical_id(type_b)
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn apply_to_type_schema_does_not_replace_non_substituted_ids_in_constraint_values() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.constraints.insert(
+            type_a,
+            vec![Constraint::HasField(HasFieldConstraint {
+                field_name: "hello".to_owned(),
+                field_type: type_b,
+            })],
+        );
+        schema.constraints.insert(
+            type_b,
+            vec![Constraint::HasMethod(HasMethodConstraint {
+                method_name: "world".to_owned(),
+                method_type: type_c,
+            })],
+        );
+        schema
+            .constraints
+            .insert(type_c, vec![Constraint::HasReturnType(type_a)]);
+        substitutions.set_types_equal(type_a, type_b);
+        let new_schema = substitutions.apply_to_type_schema(schema);
+        for (_, constraint_vec) in new_schema.constraints {
+            for constraint in constraint_vec {
+                match constraint {
+                    Constraint::HasMethod(has_method_constraint) => {
+                        assert_eq!(
+                            substitutions.get_canonical_id(has_method_constraint.method_type),
+                            substitutions.get_canonical_id(type_c)
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn apply_to_type_schema_replaces_all_instances_of_a_given_id_in_import_values() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.imports.insert("apple".to_owned(), type_a);
+        schema.imports.insert("banana".to_owned(), type_b);
+        schema.imports.insert("carrot".to_owned(), type_c);
+        substitutions.set_types_equal(type_a, type_b);
+        assert_eq!(
+            substitutions.get_canonical_id(*schema.imports.get("apple").unwrap()),
+            substitutions.get_canonical_id(type_a)
+        );
+        assert_eq!(
+            substitutions.get_canonical_id(*schema.imports.get("apple").unwrap()),
+            substitutions.get_canonical_id(type_b)
+        );
+        assert_eq!(
+            substitutions.get_canonical_id(*schema.imports.get("banana").unwrap()),
+            substitutions.get_canonical_id(type_a)
+        );
+        assert_eq!(
+            substitutions.get_canonical_id(*schema.imports.get("banana").unwrap()),
+            substitutions.get_canonical_id(type_b)
+        );
+    }
+
+    #[test]
+    fn apply_to_type_schema_does_not_replace_non_substituted_ids_in_import_values() {
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let mut schema = TypeSchema::new();
+        let type_a = schema.make_id();
+        let type_b = schema.make_id();
+        let type_c = schema.make_id();
+        substitutions.insert_new_id(type_a);
+        substitutions.insert_new_id(type_b);
+        substitutions.insert_new_id(type_c);
+        schema.imports.insert("apple".to_owned(), type_a);
+        schema.imports.insert("banana".to_owned(), type_b);
+        schema.imports.insert("carrot".to_owned(), type_c);
+        substitutions.set_types_equal(type_a, type_b);
+        assert_eq!(
+            substitutions.get_canonical_id(*schema.imports.get("carrot").unwrap()),
+            substitutions.get_canonical_id(type_c)
+        );
+    }
+}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
