### PR TITLE
Add ability to print JS expressions

### DIFF
--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,0 +1,51 @@
+use crate::{
+    identifier::print_identifier,
+    literals::{print_integer_literal, print_string_literal},
+};
+use typed_ast::ConcreteExpression;
+
+pub fn print_expression(expression: &ConcreteExpression) -> String {
+    match expression {
+        ConcreteExpression::Identifier(identifier) => print_identifier(identifier),
+        ConcreteExpression::Integer(integer) => print_integer_literal(integer),
+        ConcreteExpression::StringLiteral(string) => print_string_literal(string),
+        _ => unimplemented!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{
+        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression,
+        ConcreteStringLiteralExpression, ConcreteType,
+    };
+
+    #[test]
+    fn can_print_identifier() {
+        let expression = ConcreteExpression::Identifier(Box::new(ConcreteIdentifierExpression {
+            expression_type: ConcreteType::default_for_test(),
+            name: "foo".to_string(),
+        }));
+        assert_eq!(print_expression(&expression), "foo");
+    }
+
+    #[test]
+    fn can_print_integer_literal() {
+        let expression = ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+            expression_type: ConcreteType::default_for_test(),
+            value: 42,
+        }));
+        assert_eq!(print_expression(&expression), "42");
+    }
+
+    #[test]
+    fn can_print_string_literal() {
+        let expression =
+            ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                expression_type: ConcreteType::default_for_test(),
+                value: "foo".to_string(),
+            }));
+        assert_eq!(print_expression(&expression), "\"foo\"");
+    }
+}

--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -1,2 +1,3 @@
+mod expression;
 mod identifier;
 mod literals;

--- a/rust/js_backend/src/literals/mod.rs
+++ b/rust/js_backend/src/literals/mod.rs
@@ -1,2 +1,5 @@
 mod integer;
 mod string;
+
+pub use integer::print_integer_literal;
+pub use string::print_string_literal;

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -42,3 +42,9 @@ pub enum ConcreteType {
     List(Box<ConcreteListType>),
     Record(Box<ConcreteRecordType>),
 }
+
+impl ConcreteType {
+    pub const fn default_for_test() -> Self {
+        Self::Primitive(PrimitiveType::Str)
+    }
+}


### PR DESCRIPTION
This is just the start of the implementation. As I add more types of expressions, I'll continue to add the other branches of the match statement.

It's just a chicken-and-egg situation right now since all other expressions require the expression printer.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
