### PR TITLE
Add ability to print JS lists

### DIFF
--- a/rust/concrete_ast/src/nodes.rs
+++ b/rust/concrete_ast/src/nodes.rs
@@ -44,10 +44,8 @@ pub struct ConcreteIntegerLiteralExpression {
     pub value: u64,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConcreteListExpression {
-    pub concrete_type: ConcreteType,
     pub contents: Vec<ConcreteExpression>,
 }
 

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -1,0 +1,64 @@
+use super::print_expression;
+use concrete_ast::ConcreteListExpression;
+
+pub fn print_list(list: &ConcreteListExpression) -> String {
+    let mut result = String::new();
+    result.push('[');
+    for (index, item) in list.contents.iter().enumerate() {
+        result.push_str(&print_expression(item));
+        if index < list.contents.len() - 1 {
+            result.push(',');
+        }
+    }
+    result.push(']');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use concrete_ast::{
+        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
+    };
+
+    use super::*;
+
+    #[test]
+    fn can_print_list_of_integers() {
+        let list = ConcreteListExpression {
+            contents: vec![
+                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    value: 42,
+                })),
+                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    value: 43,
+                })),
+            ],
+        };
+        assert_eq!(print_list(&list), "[42,43]");
+    }
+
+    #[test]
+    fn does_not_include_comma_with_one_item() {
+        let list = ConcreteListExpression {
+            contents: vec![ConcreteExpression::Integer(Box::new(
+                ConcreteIntegerLiteralExpression { value: 42 },
+            ))],
+        };
+        assert_eq!(print_list(&list), "[42]");
+    }
+
+    #[test]
+    fn can_print_list_of_strings() {
+        let list = ConcreteListExpression {
+            contents: vec![
+                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                    value: "foo".to_string(),
+                })),
+                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                    value: "bar".to_string(),
+                })),
+            ],
+        };
+        assert_eq!(print_list(&list), "[\"foo\",\"bar\"]");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,3 +1,4 @@
+mod list;
 mod record;
 
 use self::record::print_record;
@@ -13,6 +14,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Integer(integer) => print_integer_literal(integer),
         ConcreteExpression::StringLiteral(string) => print_string_literal(string),
         ConcreteExpression::Record(record) => print_record(record),
+        ConcreteExpression::List(list) => list::print_list(list),
         _ => unimplemented!(),
     }
 }
@@ -71,5 +73,15 @@ mod test {
                 ],
             }));
         assert_eq!(print_expression(&expression), "{foo: 42, bar: \"baz\"}");
+    }
+
+    #[test]
+    fn can_print_list() {
+        let expression = ConcreteExpression::List(Box::new(concrete_ast::ConcreteListExpression {
+            contents: vec![ConcreteExpression::Integer(Box::new(
+                ConcreteIntegerLiteralExpression { value: 42 },
+            ))],
+        }));
+        assert_eq!(print_expression(&expression), "[42]");
     }
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-record","parentHead":"26478eab70a2e5efafd8ee0590304cee054e0fa6","parentPull":17,"trunk":"main"}
```
-->
