### PR TITLE
Print unary operator to JS

### DIFF
--- a/rust/concrete_ast/src/nodes.rs
+++ b/rust/concrete_ast/src/nodes.rs
@@ -65,10 +65,8 @@ pub struct ConcreteTagExpression {
     pub contents: Vec<ConcreteExpression>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConcreteUnaryOperatorExpression {
-    pub concrete_type: ConcreteType,
     pub symbol: UnaryOperatorSymbol,
     pub child: ConcreteExpression,
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,6 +1,7 @@
 mod binary_operator;
 mod list;
 mod record;
+mod unary_operator;
 
 use self::record::print_record;
 use crate::{
@@ -19,6 +20,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::BinaryOperator(operator) => {
             binary_operator::print_binary_operator(operator)
         }
+        ConcreteExpression::UnaryOperator(operator) => {
+            unary_operator::print_unary_operator(operator)
+        }
         _ => unimplemented!(),
     }
 }
@@ -26,7 +30,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ast::BinaryOperatorSymbol;
+    use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use concrete_ast::{
         ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression,
         ConcreteStringLiteralExpression,
@@ -108,5 +112,18 @@ mod test {
             },
         ));
         assert_eq!(print_expression(&expression), "foo.bar");
+    }
+
+    #[test]
+    fn can_print_unary_operator() {
+        let expression = ConcreteExpression::UnaryOperator(Box::new(
+            concrete_ast::ConcreteUnaryOperatorExpression {
+                symbol: UnaryOperatorSymbol::Negative,
+                child: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    value: 42,
+                })),
+            },
+        ));
+        assert_eq!(print_expression(&expression), "-42");
     }
 }

--- a/rust/js_backend/src/expression/unary_operator.rs
+++ b/rust/js_backend/src/expression/unary_operator.rs
@@ -1,0 +1,57 @@
+use ast::UnaryOperatorSymbol;
+use concrete_ast::ConcreteUnaryOperatorExpression;
+
+const fn should_include_space(operator: &UnaryOperatorSymbol) -> bool {
+    match operator {
+        UnaryOperatorSymbol::Negative => false,
+        UnaryOperatorSymbol::Not => true,
+    }
+}
+
+fn print_unary_operator_symbol(operator: &UnaryOperatorSymbol) -> String {
+    match operator {
+        UnaryOperatorSymbol::Negative => "-".to_string(),
+        UnaryOperatorSymbol::Not => "not".to_string(),
+    }
+}
+
+pub fn print_unary_operator(expression: &ConcreteUnaryOperatorExpression) -> String {
+    let mut result = String::new();
+    result.push_str(&print_unary_operator_symbol(&expression.symbol));
+    if should_include_space(&expression.symbol) {
+        result.push(' ');
+    }
+    result.push_str(&super::print_expression(&expression.child));
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ast::UnaryOperatorSymbol;
+    use concrete_ast::{
+        ConcreteExpression, ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression,
+    };
+
+    #[test]
+    fn can_print_negative_integer() {
+        let expression = ConcreteUnaryOperatorExpression {
+            symbol: UnaryOperatorSymbol::Negative,
+            child: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                value: 42,
+            })),
+        };
+        assert_eq!(print_unary_operator(&expression), "-42");
+    }
+
+    #[test]
+    fn can_print_not_boolean() {
+        let expression = ConcreteUnaryOperatorExpression {
+            symbol: UnaryOperatorSymbol::Not,
+            child: ConcreteExpression::Identifier(Box::new(ConcreteIdentifierExpression {
+                name: "true".to_string(),
+            })),
+        };
+        assert_eq!(print_unary_operator(&expression), "not true");
+    }
+}


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-binary-operator","parentHead":"7f5e17ae1db859d103a4fef28c6d7ea933ee26ca","parentPull":19,"trunk":"main"}
```
-->
