### PR TITLE
Print JS function declaration expressions

### DIFF
--- a/rust/concrete_ast/src/nodes.rs
+++ b/rust/concrete_ast/src/nodes.rs
@@ -1,4 +1,4 @@
-use crate::concrete_types::{ConcreteTagUnionType, ConcreteType};
+use crate::concrete_types::ConcreteTagUnionType;
 use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,10 +13,8 @@ pub struct ConcreteBlockExpression {
     pub contents: Vec<ConcreteExpression>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConcreteFunctionExpression {
-    pub concrete_type: ConcreteType,
     pub argument_names: Vec<String>,
     pub body: ConcreteExpression,
 }

--- a/rust/js_backend/src/expression/function_declaration.rs
+++ b/rust/js_backend/src/expression/function_declaration.rs
@@ -1,0 +1,66 @@
+use concrete_ast::ConcreteFunctionExpression;
+
+pub fn print_function_declaration(function: &ConcreteFunctionExpression) -> String {
+    let mut result = String::new();
+    result.push('(');
+    for (index, parameter) in function.argument_names.iter().enumerate() {
+        if index > 0 {
+            result.push(',');
+        }
+        result.push_str(parameter.as_str());
+    }
+    result.push_str(")=>(");
+    result.push_str(super::print_expression(&function.body).as_str());
+    result.push(')');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use concrete_ast::{ConcreteExpression, ConcreteIntegerLiteralExpression};
+
+    #[test]
+    fn prints_a_function_with_no_arguments() {
+        let function = ConcreteFunctionExpression {
+            argument_names: vec![],
+            body: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                value: 42,
+            })),
+        };
+        assert_eq!(print_function_declaration(&function), "()=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_one_argument() {
+        let function = ConcreteFunctionExpression {
+            argument_names: vec!["x".to_string()],
+            body: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                value: 42,
+            })),
+        };
+        assert_eq!(print_function_declaration(&function), "(x)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_two_arguments() {
+        let function = ConcreteFunctionExpression {
+            argument_names: vec!["x".to_string(), "y".to_string()],
+            body: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                value: 42,
+            })),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_three_arguments() {
+        let function = ConcreteFunctionExpression {
+            argument_names: vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            body: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                value: 42,
+            })),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y,z)=>(42)");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,5 +1,6 @@
 mod binary_operator;
 mod code_block;
+mod function_declaration;
 mod if_expression;
 mod list;
 mod record;
@@ -29,7 +30,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         ConcreteExpression::If(if_expression) => if_expression::print_if(if_expression),
         ConcreteExpression::Block(code_block) => code_block::print_code_block(code_block),
-        ConcreteExpression::Function(_) => unimplemented!(),
+        ConcreteExpression::Function(function_declaration) => {
+            function_declaration::print_function_declaration(function_declaration)
+        }
     }
 }
 
@@ -175,5 +178,17 @@ mod test {
                 ],
             }));
         assert_eq!(print_expression(&expression), "(()=>{42;return 24;})()");
+    }
+
+    #[test]
+    fn can_print_function_declaration() {
+        let expression =
+            ConcreteExpression::Function(Box::new(concrete_ast::ConcreteFunctionExpression {
+                argument_names: vec![],
+                body: ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    value: 42,
+                })),
+            }));
+        assert_eq!(print_expression(&expression), "()=>(42)");
     }
 }


### PR DESCRIPTION
The extra parenthesis around the return value are probably redundant. However, they will not cause bugs.

When we get a more complete e2e coverage we can revisit this and see if the parenthesis are unnecessary.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-codeblock","parentHead":"f9ac0560ed1fedb274ccacfde5cf75f5f6714b64","parentPull":24,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-codeblock","parentHead":"f9ac0560ed1fedb274ccacfde5cf75f5f6714b64","parentPull":24,"trunk":"main"}
```
-->
