### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "rust/typed_ast",
 ]
 
+[workspace.dependencies]
+nom = "7.1.3"
+nom_locate = "4.0.0"
+
 [toolchain]
 channel = "1.66.0"
 components = ["rustfmt", "clippy", "cargo-cranky"]

--- a/rust/ast/Cargo.toml
+++ b/rust/ast/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7.1.3"
-nom_locate = "4.0.0"
+nom.workspace = true
+nom_locate.workspace = true

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 ast = { path = "../ast" }
-nom = "7.1.3"
+nom.workspace = true


### PR DESCRIPTION
Today I discovered that Cargo allows you to define versions of external dependencies in the top-level Cargo.toml file.

This PR converts all our dependencies to use these workspace dependencies. That way, we ensure we have a single version of every dependency (and it's easy to change those versions).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-expression","parentHead":"23aeea8935d41a4ef45562d4d120bcecc2406946","parentPull":29,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-expression","parentHead":"23aeea8935d41a4ef45562d4d120bcecc2406946","parentPull":29,"trunk":"main"}
```
-->
