### PR TITLE
Remove unnecessary type annotations and unused argument

### DIFF
--- a/rust/parser/src/document.rs
+++ b/rust/parser/src/document.rs
@@ -21,9 +21,7 @@ enum DocumentElement<'a> {
     Expression(Expression<'a>),
 }
 
-pub fn document<'a>(
-    context: ExpressionContext,
-) -> impl FnMut(ParserInput<'a>) -> IResult<'a, DocumentNode<'a>> {
+pub fn document<'a>() -> impl FnMut(ParserInput<'a>) -> IResult<'a, DocumentNode<'a>> {
     map(
         consumed(many0(alt((
             map(
@@ -79,7 +77,7 @@ mod test {
     #[test]
     fn blank_document_is_document() {
         let input = ParserInput::new("");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -87,7 +85,7 @@ mod test {
     #[test]
     fn import_is_document() {
         let input = ParserInput::new("import a from \"file.buri\"");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -95,7 +93,7 @@ mod test {
     #[test]
     fn import_value_is_preserved() {
         let input = ParserInput::new("import a from \"file.buri\"");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.imports.len(), 1);
         assert!(matches!(
@@ -113,7 +111,7 @@ mod test {
     #[test]
     fn type_declaration_is_document() {
         let input = ParserInput::new("Hello = World");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -121,7 +119,7 @@ mod test {
     #[test]
     fn type_declaration_value_is_preserved() {
         let input = ParserInput::new("Hello = World");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.type_declarations.len(), 1);
         assert_eq!(
@@ -140,7 +138,7 @@ mod test {
     #[test]
     fn literal_is_document() {
         let input = ParserInput::new("0");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -148,7 +146,7 @@ mod test {
     #[test]
     fn literal_value_is_preserved() {
         let input = ParserInput::new("314");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.expressions.len(), 1);
         assert!(matches!(
@@ -160,7 +158,7 @@ mod test {
     #[test]
     fn identifier_is_document() {
         let input = ParserInput::new("hello");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -168,7 +166,7 @@ mod test {
     #[test]
     fn variable_declaration_is_document() {
         let input = ParserInput::new("hello = world");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -176,7 +174,7 @@ mod test {
     #[test]
     fn function_call_is_document() {
         let input = ParserInput::new("main()");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -184,7 +182,7 @@ mod test {
     #[test]
     fn variable_declaration_value_is_preserved() {
         let input = ParserInput::new("hello = world");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.variable_declarations.len(), 1);
         assert_eq!(
@@ -204,7 +202,7 @@ mod test {
     #[test]
     fn document_can_contain_multiple_lines_of_different_types() {
         let input = ParserInput::new("import a from \"file.buri\"\nHello = World\na");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -212,7 +210,7 @@ mod test {
     #[test]
     fn document_can_contain_empty_lines() {
         let input = ParserInput::new("import a from \"file.buri\"\n\na");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }

--- a/rust/parser/src/list.rs
+++ b/rust/parser/src/list.rs
@@ -10,7 +10,7 @@ use nom::{
     sequence::{delimited, preceded, terminated, tuple},
 };
 
-fn padded_expression<'a>(input: ParserInput<'a>) -> IResult<'a, Expression<'a>> {
+fn padded_expression(input: ParserInput) -> IResult<Expression> {
     preceded(
         opt(intra_expression_whitespace(
             ExpressionContext::new().allow_newlines_in_expressions(),
@@ -19,7 +19,7 @@ fn padded_expression<'a>(input: ParserInput<'a>) -> IResult<'a, Expression<'a>> 
     )(input)
 }
 
-fn padded_comma<'a>(input: ParserInput<'a>) -> IResult<'a, ParserInput<'a>> {
+fn padded_comma(input: ParserInput) -> IResult<ParserInput> {
     preceded(
         opt(intra_expression_whitespace(
             ExpressionContext::new().allow_newlines_in_expressions(),
@@ -28,7 +28,7 @@ fn padded_comma<'a>(input: ParserInput<'a>) -> IResult<'a, ParserInput<'a>> {
     )(input)
 }
 
-fn list_contents<'a>(input: ParserInput<'a>) -> IResult<'a, Vec<Expression<'a>>> {
+fn list_contents(input: ParserInput) -> IResult<Vec<Expression>> {
     map(
         tuple((
             padded_expression,
@@ -44,7 +44,7 @@ fn list_contents<'a>(input: ParserInput<'a>) -> IResult<'a, Vec<Expression<'a>>>
     )(input)
 }
 
-pub fn list<'a>(input: ParserInput<'a>) -> IResult<'a, ListNode<'a>> {
+pub fn list(input: ParserInput) -> IResult<ListNode> {
     map(
         consumed(delimited(
             tag("["),


### PR DESCRIPTION
Clippy cleanup stuffs.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"workspace-deps","parentHead":"2c370015971c806c0f7b8009fceb4e35813f7406","parentPull":30,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"workspace-deps","parentHead":"2c370015971c806c0f7b8009fceb4e35813f7406","parentPull":30,"trunk":"main"}
```
-->
