### PR TITLE
Simplify concrete expression creation for tests

### DIFF
--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -16,10 +16,7 @@ pub fn print_list(list: &ConcreteListExpression) -> String {
 
 #[cfg(test)]
 mod test {
-    use typed_ast::{
-        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
-        ConcreteType,
-    };
+    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
 
     use super::*;
 
@@ -28,14 +25,8 @@ mod test {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                })),
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 43,
-                })),
+                ConcreteExpression::integer_for_test(42),
+                ConcreteExpression::integer_for_test(43),
             ],
         };
         assert_eq!(print_list(&list), "[42,43]");
@@ -45,12 +36,7 @@ mod test {
     fn does_not_include_comma_with_one_item() {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
-            contents: vec![ConcreteExpression::Integer(Box::new(
-                ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                },
-            ))],
+            contents: vec![ConcreteExpression::integer_for_test(42)],
         };
         assert_eq!(print_list(&list), "[42]");
     }
@@ -60,14 +46,8 @@ mod test {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![
-                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                    expression_type: ConcreteType::default_string_for_test(),
-                    value: "foo".to_string(),
-                })),
-                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                    expression_type: ConcreteType::default_string_for_test(),
-                    value: "bar".to_string(),
-                })),
+                ConcreteExpression::string_for_test("foo"),
+                ConcreteExpression::string_for_test("bar"),
             ],
         };
         assert_eq!(print_list(&list), "[\"foo\",\"bar\"]");

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -24,35 +24,25 @@ mod test {
 
     use super::*;
     use typed_ast::{
-        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression, ConcreteListExpression,
-        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteType,
+        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
+        ConcreteType,
     };
 
     #[test]
     fn can_print_identifier() {
-        let expression = ConcreteExpression::Identifier(Box::new(ConcreteIdentifierExpression {
-            expression_type: ConcreteType::default_for_test(),
-            name: "foo".to_string(),
-        }));
+        let expression = ConcreteExpression::identifier_for_test("foo");
         assert_eq!(print_expression(&expression), "foo");
     }
 
     #[test]
     fn can_print_integer_literal() {
-        let expression = ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-            expression_type: ConcreteType::default_for_test(),
-            value: 42,
-        }));
+        let expression = ConcreteExpression::integer_for_test(42);
         assert_eq!(print_expression(&expression), "42");
     }
 
     #[test]
     fn can_print_string_literal() {
-        let expression =
-            ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                expression_type: ConcreteType::default_for_test(),
-                value: "foo".to_string(),
-            }));
+        let expression = ConcreteExpression::string_for_test("foo");
         assert_eq!(print_expression(&expression), "\"foo\"");
     }
 
@@ -61,13 +51,7 @@ mod test {
         let expression = ConcreteExpression::Record(Box::new(ConcreteRecordExpression {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([
-                (
-                    "foo".to_string(),
-                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                        expression_type: ConcreteType::default_integer_for_test(),
-                        value: 42,
-                    })),
-                ),
+                ("foo".to_string(), ConcreteExpression::integer_for_test(42)),
                 (
                     "bar".to_string(),
                     ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
@@ -89,12 +73,7 @@ mod test {
     fn can_print_list() {
         let list = ConcreteExpression::List(Box::new(ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
-            contents: vec![ConcreteExpression::Integer(Box::new(
-                ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                },
-            ))],
+            contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
         assert_eq!(print_expression(&list), "[42]");
     }

--- a/rust/js_backend/src/expression/record.rs
+++ b/rust/js_backend/src/expression/record.rs
@@ -21,29 +21,17 @@ mod test {
     use std::collections::HashMap;
 
     use super::*;
-    use typed_ast::{
-        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
-        ConcreteType,
-    };
+    use typed_ast::{ConcreteExpression, ConcreteType};
 
     #[test]
     fn can_print_record() {
         let record = ConcreteRecordExpression {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([
-                (
-                    "foo".to_string(),
-                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                        expression_type: ConcreteType::default_integer_for_test(),
-                        value: 42,
-                    })),
-                ),
+                ("foo".to_string(), ConcreteExpression::integer_for_test(42)),
                 (
                     "bar".to_string(),
-                    ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                        expression_type: ConcreteType::default_string_for_test(),
-                        value: "baz".to_string(),
-                    })),
+                    ConcreteExpression::string_for_test("baz"),
                 ),
             ]),
         };
@@ -61,10 +49,7 @@ mod test {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([(
                 "foo".to_string(),
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                })),
+                ConcreteExpression::integer_for_test(42),
             )]),
         };
         assert_eq!(print_record(&record), "{foo: 42}");

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -20,3 +20,29 @@ pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
+
+impl ConcreteExpression {
+    #[must_use]
+    pub fn identifier_for_test(name: &str) -> Self {
+        Self::Identifier(Box::new(ConcreteIdentifierExpression {
+            expression_type: ConcreteType::default_for_test(),
+            name: name.to_string(),
+        }))
+    }
+
+    #[must_use]
+    pub fn string_for_test(string: &str) -> Self {
+        Self::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+            expression_type: ConcreteType::default_string_for_test(),
+            value: string.to_string(),
+        }))
+    }
+
+    #[must_use]
+    pub fn integer_for_test(int: u64) -> Self {
+        Self::Integer(Box::new(ConcreteIntegerLiteralExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            value: int,
+        }))
+    }
+}


### PR DESCRIPTION
For the vast majority of the tests, the type and structure of `ConcreteExpression`s are not important. Therefore, I abstracted that away into helper methods to simplify the tests.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-list","parentHead":"9078dd7568936f4eec6d4a9a280f5ef0b9965444","parentPull":33,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-list","parentHead":"9078dd7568936f4eec6d4a9a280f5ef0b9965444","parentPull":33,"trunk":"main"}
```
-->
