### PR TITLE
Add parenthesis around all JS integer literals

### DIFF
--- a/rust/js_backend/src/expression/binary_operator.rs
+++ b/rust/js_backend/src/expression/binary_operator.rs
@@ -80,7 +80,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.add(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).add((2))");
     }
 
     #[test]
@@ -91,7 +91,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "(1+2)");
+        assert_eq!(print_binary_operator(&expression), "((1)+(2))");
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.subtract(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).subtract((2))");
     }
 
     #[test]
@@ -113,7 +113,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.multiply(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).multiply((2))");
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.divide(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).divide((2))");
     }
 
     #[test]
@@ -135,7 +135,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.power(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).power((2))");
     }
 
     #[test]
@@ -146,7 +146,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.modulo(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).modulo((2))");
     }
 
     #[test]
@@ -157,7 +157,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.equals(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).equals((2))");
     }
 
     #[test]
@@ -168,7 +168,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.notEquals(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).notEquals((2))");
     }
 
     #[test]
@@ -179,7 +179,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.lessThan(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).lessThan((2))");
     }
 
     #[test]
@@ -190,7 +190,10 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.lessThanOrEquals(2)");
+        assert_eq!(
+            print_binary_operator(&expression),
+            "(1).lessThanOrEquals((2))"
+        );
     }
 
     #[test]
@@ -201,7 +204,7 @@ mod test {
             left_child: ConcreteExpression::integer_for_test(1),
             right_child: ConcreteExpression::integer_for_test(2),
         };
-        assert_eq!(print_binary_operator(&expression), "1.greaterThan(2)");
+        assert_eq!(print_binary_operator(&expression), "(1).greaterThan((2))");
     }
 
     #[test]
@@ -214,7 +217,7 @@ mod test {
         };
         assert_eq!(
             print_binary_operator(&expression),
-            "1.greaterThanOrEquals(2)"
+            "(1).greaterThanOrEquals((2))"
         );
     }
 

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -29,7 +29,7 @@ mod test {
                 ConcreteExpression::integer_for_test(43),
             ],
         };
-        assert_eq!(print_list(&list), "[42,43]");
+        assert_eq!(print_list(&list), "[(42),(43)]");
     }
 
     #[test]
@@ -38,7 +38,7 @@ mod test {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![ConcreteExpression::integer_for_test(42)],
         };
-        assert_eq!(print_list(&list), "[42]");
+        assert_eq!(print_list(&list), "[(42)]");
     }
 
     #[test]

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -38,7 +38,7 @@ mod test {
     #[test]
     fn can_print_integer_literal() {
         let expression = ConcreteExpression::integer_for_test(42);
-        assert_eq!(print_expression(&expression), "42");
+        assert_eq!(print_expression(&expression), "(42)");
     }
 
     #[test]
@@ -65,8 +65,8 @@ mod test {
         // Because of the HashMap, the order of the keys is not guaranteed.
         // However, the order doesn't matter so we can accept either one.
         assert!(
-            print_expression(&expression) == "{bar: \"baz\", foo: 42}"
-                || print_expression(&expression) == "{foo: 42, bar: \"baz\"}"
+            print_expression(&expression) == "{bar: \"baz\", foo: (42)}"
+                || print_expression(&expression) == "{foo: (42), bar: \"baz\"}"
         );
     }
 
@@ -76,6 +76,6 @@ mod test {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
-        assert_eq!(print_expression(&list), "[42]");
+        assert_eq!(print_expression(&list), "[(42)]");
     }
 }

--- a/rust/js_backend/src/expression/record.rs
+++ b/rust/js_backend/src/expression/record.rs
@@ -38,8 +38,8 @@ mod test {
         // Because of the HashMap, the order of the keys is not guaranteed.
         // However, the order doesn't matter so we can accept either one.
         assert!(
-            print_record(&record) == "{bar: \"baz\", foo: 42}"
-                || print_record(&record) == "{foo: 42, bar: \"baz\"}"
+            print_record(&record) == "{bar: \"baz\", foo: (42)}"
+                || print_record(&record) == "{foo: (42), bar: \"baz\"}"
         );
     }
 
@@ -52,6 +52,6 @@ mod test {
                 ConcreteExpression::integer_for_test(42),
             )]),
         };
-        assert_eq!(print_record(&record), "{foo: 42}");
+        assert_eq!(print_record(&record), "{foo: (42)}");
     }
 }

--- a/rust/js_backend/src/literals/integer.rs
+++ b/rust/js_backend/src/literals/integer.rs
@@ -1,9 +1,7 @@
 use typed_ast::ConcreteIntegerLiteralExpression;
 
 pub fn print_integer_literal(node: &ConcreteIntegerLiteralExpression) -> String {
-    let mut result = String::new();
-    result.push_str(&node.value.to_string());
-    result
+    format!("({})", node.value)
 }
 
 #[cfg(test)]
@@ -18,7 +16,7 @@ mod test {
             expression_type: ConcreteType::Primitive(PrimitiveType::Num),
             value: 1,
         };
-        assert_eq!(print_integer_literal(&node), "1");
+        assert_eq!(print_integer_literal(&node), "(1)");
     }
 
     #[test]
@@ -27,6 +25,6 @@ mod test {
             expression_type: ConcreteType::Primitive(PrimitiveType::Num),
             value: 2,
         };
-        assert_eq!(print_integer_literal(&node), "2");
+        assert_eq!(print_integer_literal(&node), "(2)");
     }
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-binary-operator","parentHead":"30a658b94dbef53f84ef64011435554e7d8f31c8","parentPull":35,"trunk":"main"}
```
-->
