### PR TITLE
Print JS code blocks

### DIFF
--- a/rust/js_backend/src/expression/block.rs
+++ b/rust/js_backend/src/expression/block.rs
@@ -1,0 +1,57 @@
+use typed_ast::ConcreteBlockExpression;
+
+pub fn print_block(block: &ConcreteBlockExpression) -> String {
+    if block.contents.is_empty() {
+        return String::new();
+    }
+    if block.contents.len() == 1 {
+        return super::print_expression(&block.contents[0]);
+    }
+    let mut result = String::new();
+    result.push_str("(()=>{");
+    for (index, expression) in block.contents.iter().enumerate() {
+        if index == &block.contents.len() - 1 {
+            result.push_str("return ");
+        }
+        result.push_str(super::print_expression(expression).as_str());
+        result.push(';');
+    }
+    result.push_str("})()");
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn an_empty_code_block_produces_an_empty_string() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![],
+        };
+        assert_eq!(print_block(&block), "");
+    }
+
+    #[test]
+    fn a_code_block_with_one_expression_produces_the_expression() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![ConcreteExpression::integer_for_test(42)],
+        };
+        assert_eq!(print_block(&block), "42");
+    }
+
+    #[test]
+    fn a_code_block_with_two_or_more_expressions_produces_an_immediately_invoked_function() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![
+                ConcreteExpression::integer_for_test(42),
+                ConcreteExpression::integer_for_test(43),
+            ],
+        };
+        assert_eq!(print_block(&block), "(()=>{42;return 43;})()");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,4 +1,5 @@
 mod binary_operator;
+mod block;
 mod if_expression;
 mod list;
 mod record;
@@ -26,6 +27,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         }
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
+        ConcreteExpression::Block(block) => block::print_block(block),
         _ => unimplemented!(),
     }
 }
@@ -37,9 +39,9 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteIfExpression, ConcreteListExpression,
-        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteTagExpression,
-        ConcreteType, ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteIfExpression,
+        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
+        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -134,5 +136,14 @@ mod test {
             path_if_false: Some(ConcreteExpression::identifier_for_test("baz")),
         }));
         assert_eq!(print_expression(&expression), "(foo?bar:baz)");
+    }
+
+    #[test]
+    fn print_block() {
+        let block = ConcreteExpression::Block(Box::new(ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![ConcreteExpression::integer_for_test(42)],
+        }));
+        assert_eq!(print_expression(&block), "42");
     }
 }


### PR DESCRIPTION
There's one interesting difference between Buri code blocks and JS code blocks that prevents us from using a 1-to-1 mapping: Buri code blocks automatically return their final expression. Because of this, I opted to compile code blocks into immediately invoked functions.

While this does have performance drawbacks, I think it's acceptable in the MVP. For future iterations, though, we'll want to put in more thought on how to compile the code blocks. However, this will always require knowing more context.

For instance, if the "return" value of the code block is never used, we can simply use a JS code block.

And let's consider the scenario of using a code block inside an if statement to assign a variable. We could potentially use something like the following:

```buri
-- buri
hello = if isOne do
    1
else
    0
```

```js
// js
let hello;
if (isOne) {
    hello = 1;
} else {
    hello = 0;
}
```

_Note: technically in the above example we can just use a ternary operator and inline the single expression in the code block (which would be simpler: `let hello = isOne ? 1 : 0;`). However, I chose this example because it demonstrates the concept I wanted to explain very simply._

One other interesting way of optimizing this is what [Rescript does](https://rescript-lang.org/try?code=LYewJgrgNgpgBAIQgF2SAdnAvHA3gKDjgAEAnGAQwGNkA6KkYABwxnWULlmTmAoGt4OABQA-BhHYAuOAEt2ASmwA+PJyLc4FUqWxwA2uqJyAZnAns4qgAxrj9uACkAzrSggA5sIBEAI1IU6FQAFnAAjN4KANxG9t7BMFDu3rFwAL5wic7wBACQuZogKEwoet4A7iCkUGDeMflFyCUcDulGALr4BTA8wM4eetqk+tad9gA8viho6Kq4fR4AtMoASpQ0tM7IpPIeGeMA9FOoGMqcafgXQA). Rescript does two major performance optimizations:

1. It will inline all variable declarations and operations into a single, non-multiline expression (basically compiling away the code block).
2. If there's an effect that happens before the return value, it will compile it into a tuple. In JS, the last value of a tuple is implicitly returned.

So, here's how Rescript compiles code:

```rescript
// Rescript

let arr = [
    if count > 0 {
        Js.log("hello")
        0
    } else {
        1
    }
]
```

```js
// js

let arr = [count > 0 ? (console.log("hello"), 0) : 1]
```

I have figured out how to confuse the Rescript compiler in a few ways, for instance, with [using a variable in a function with a side effect then returning that variable](https://rescript-lang.org/try?code=LYewJgrgNgpgBAIQgF2SAdnAvHA3gKDjgAEAnGAQwGNkA6KkYABwxnWULlmTmAoGt4OABQA-BhHYAuOAEt2ASmwA+PJyLc4FUqWxwA2uqJyAZnAns4qgAxrj9rjB4ALGFCgg9AIlfuQXo3sAKQBnWg8Ac2FfDwUAbkDjGJBEgF84NxD4AgBIHM0QFCYUbwB3EFIoMC8EvMLkYo4HOFSjAF18fKdeEIi9bVJ9aw77AB4AIxQ0dFVcYF6AWmUAJUoaWhDkUnkI9NGAeknUDGVOVtagA). But for those, it will then pull the if statement above the place it's used to have a normal if statement. It will then just assign things to a temporary variable and use that.

I'd like to eventually do these kinds of optimizations, but I don't think now's the time.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-if","parentHead":"b3b215d344cdf8ac1611c962cee7b28f6c33fc20","parentPull":40,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-if","parentHead":"b3b215d344cdf8ac1611c962cee7b28f6c33fc20","parentPull":40,"trunk":"main"}
```
-->
