### PR TITLE
Print JS function declarations

### DIFF
--- a/rust/js_backend/src/expression/function_declaration.rs
+++ b/rust/js_backend/src/expression/function_declaration.rs
@@ -1,0 +1,62 @@
+use typed_ast::ConcreteFunctionExpression;
+
+pub fn print_function_declaration(function: &ConcreteFunctionExpression) -> String {
+    let mut result = String::new();
+    result.push('(');
+    for (index, parameter) in function.argument_names.iter().enumerate() {
+        if index > 0 {
+            result.push(',');
+        }
+        result.push_str(parameter.as_str());
+    }
+    result.push_str(")=>(");
+    result.push_str(super::print_expression(&function.body).as_str());
+    result.push(')');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn prints_a_function_with_no_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec![],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "()=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_one_argument() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_two_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string(), "y".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_three_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y,z)=>(42)");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,5 +1,6 @@
 mod binary_operator;
 mod block;
+mod function_declaration;
 mod if_expression;
 mod list;
 mod record;
@@ -28,7 +29,10 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
         ConcreteExpression::Block(block) => block::print_block(block),
-        _ => unimplemented!(),
+        ConcreteExpression::Function(function) => {
+            function_declaration::print_function_declaration(function)
+        }
+        ConcreteExpression::Boolean(_) => unimplemented!(),
     }
 }
 
@@ -39,9 +43,10 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteIfExpression,
-        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
-        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteFunctionExpression,
+        ConcreteIfExpression, ConcreteListExpression, ConcreteRecordExpression,
+        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
+        ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -145,5 +150,15 @@ mod test {
             contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
         assert_eq!(print_expression(&block), "42");
+    }
+
+    #[test]
+    fn print_function_declaration() {
+        let function = ConcreteExpression::Function(Box::new(ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec![],
+            body: ConcreteExpression::integer_for_test(42),
+        }));
+        assert_eq!(print_expression(&function), "()=>(42)");
     }
 }

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -92,4 +92,12 @@ impl ConcreteType {
             tag_types: HashMap::new(),
         }))
     }
+
+    #[must_use]
+    pub fn default_function_for_test() -> Self {
+        Self::Function(Box::new(ConcreteFunctionType {
+            argument_types: vec![],
+            return_type: None,
+        }))
+    }
 }


### PR DESCRIPTION
The extra parenthesis around the return value are probably redundant. However, they will not cause bugs.

When we get a more complete e2e coverage we can revisit this and see if the parenthesis are unnecessary.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-block","parentHead":"fc077a33d63218d4b268e14632cf14010a740024","parentPull":41,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-block","parentHead":"fc077a33d63218d4b268e14632cf14010a740024","parentPull":41,"trunk":"main"}
```
-->
