### PR TITLE
Remove stale branches automatically

### DIFF
--- a/.github/workflows/stale-branch.yml
+++ b/.github/workflows/stale-branch.yml
@@ -1,0 +1,12 @@
+on:
+  schedule:
+    - cron: "0 0 * * *" # Everday at midnight
+
+jobs:
+  remove-stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v1
+        with:
+          operations-per-run: 100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 name = "js_backend"
 version = "0.1.0"
 dependencies = [
+ "ast",
  "typed_ast",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "rust/typed_ast",
 ]
 
+[workspace.dependencies]
+nom = "7.1.3"
+nom_locate = "4.0.0"
+
 [toolchain]
 channel = "1.66.0"
 components = ["rustfmt", "clippy", "cargo-cranky"]

--- a/rust/ast/Cargo.toml
+++ b/rust/ast/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7.1.3"
-nom_locate = "4.0.0"
+nom.workspace = true
+nom_locate.workspace = true

--- a/rust/js_backend/Cargo.toml
+++ b/rust/js_backend/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ast = { path = "../ast" }
 typed_ast = { path = "../typed_ast" }

--- a/rust/js_backend/src/expression/binary_operator.rs
+++ b/rust/js_backend/src/expression/binary_operator.rs
@@ -1,0 +1,445 @@
+use ast::BinaryOperatorSymbol;
+use typed_ast::{ConcreteBinaryOperatorExpression, ConcreteExpression};
+
+enum OperatorFormat {
+    /// Do no formatting to the operator. Simply {left}{operator}{right}
+    Naked,
+    /// Add parenthesis around the entire expression. ({left}{operator}{right})
+    Parenthesized,
+    /// Call the operator like a method. ({left}).{operator}({right})
+    Method,
+}
+
+fn print_operator(operator: &BinaryOperatorSymbol) -> String {
+    match operator {
+        BinaryOperatorSymbol::Add => "add".to_string(),
+        BinaryOperatorSymbol::Subtract => "subtract".to_string(),
+        BinaryOperatorSymbol::Multiply => "multiply".to_string(),
+        BinaryOperatorSymbol::Divide => "divide".to_string(),
+        BinaryOperatorSymbol::Power => "power".to_string(),
+        BinaryOperatorSymbol::Modulus => "modulo".to_string(),
+        BinaryOperatorSymbol::EqualTo => "equals".to_string(),
+        BinaryOperatorSymbol::NotEqualTo => "notEquals".to_string(),
+        BinaryOperatorSymbol::LessThan => "lessThan".to_string(),
+        BinaryOperatorSymbol::LessThanOrEqualTo => "lessThanOrEquals".to_string(),
+        BinaryOperatorSymbol::GreaterThan => "greaterThan".to_string(),
+        BinaryOperatorSymbol::GreaterThanOrEqualTo => "greaterThanOrEquals".to_string(),
+        BinaryOperatorSymbol::And => "&&".to_string(),
+        BinaryOperatorSymbol::Or => "||".to_string(),
+        BinaryOperatorSymbol::Concatenate => "+".to_string(),
+        BinaryOperatorSymbol::MethodLookup | BinaryOperatorSymbol::FieldLookup => ".".to_string(),
+        BinaryOperatorSymbol::FunctionApplication => unreachable!(),
+    }
+}
+
+fn get_format(operator: &BinaryOperatorSymbol) -> OperatorFormat {
+    match operator {
+        BinaryOperatorSymbol::Add
+        | BinaryOperatorSymbol::Subtract
+        | BinaryOperatorSymbol::Multiply
+        | BinaryOperatorSymbol::Divide
+        | BinaryOperatorSymbol::Power
+        | BinaryOperatorSymbol::Modulus
+        | BinaryOperatorSymbol::EqualTo
+        | BinaryOperatorSymbol::NotEqualTo
+        | BinaryOperatorSymbol::LessThan
+        | BinaryOperatorSymbol::LessThanOrEqualTo
+        | BinaryOperatorSymbol::GreaterThan
+        | BinaryOperatorSymbol::GreaterThanOrEqualTo => OperatorFormat::Method,
+        BinaryOperatorSymbol::Concatenate
+        | BinaryOperatorSymbol::And
+        | BinaryOperatorSymbol::Or => OperatorFormat::Parenthesized,
+        BinaryOperatorSymbol::MethodLookup | BinaryOperatorSymbol::FieldLookup => {
+            OperatorFormat::Naked
+        }
+        BinaryOperatorSymbol::FunctionApplication => unreachable!(),
+    }
+}
+
+fn maybe_parenthesize_left(string: &str, expression: &ConcreteExpression) -> String {
+    if let ConcreteExpression::Integer(_) = expression {
+        format!("({string})")
+    } else {
+        super::print_expression(expression)
+    }
+}
+
+pub fn print_binary_operator(expression: &ConcreteBinaryOperatorExpression) -> String {
+    let operator = print_operator(&expression.symbol);
+    let left = super::print_expression(&expression.left_child);
+    let right = super::print_expression(&expression.right_child);
+    match get_format(&expression.symbol) {
+        OperatorFormat::Naked => format!(
+            "{}{operator}{right}",
+            maybe_parenthesize_left(&left, &expression.left_child)
+        ),
+        OperatorFormat::Parenthesized => format!("({left}{operator}{right})"),
+        OperatorFormat::Method => {
+            format!(
+                "{}.{}({})",
+                maybe_parenthesize_left(&left, &expression.left_child),
+                operator,
+                right
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn addition() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Add,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).add(2)");
+    }
+
+    #[test]
+    fn addition_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Add,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.add(bar)");
+    }
+
+    #[test]
+    fn concatenate() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Concatenate,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1+2)");
+    }
+
+    #[test]
+    fn subtraction() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Subtract,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).subtract(2)");
+    }
+
+    #[test]
+    fn subtraction_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Subtract,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.subtract(bar)");
+    }
+
+    #[test]
+    fn multiplication() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Multiply,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).multiply(2)");
+    }
+
+    #[test]
+    fn multiplication_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Multiply,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.multiply(bar)");
+    }
+
+    #[test]
+    fn division() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Divide,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).divide(2)");
+    }
+
+    #[test]
+    fn division_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Divide,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.divide(bar)");
+    }
+
+    #[test]
+    fn power() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Power,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).power(2)");
+    }
+
+    #[test]
+    fn power_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Power,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.power(bar)");
+    }
+
+    #[test]
+    fn modulus() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Modulus,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).modulo(2)");
+    }
+
+    #[test]
+    fn modulus_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Modulus,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.modulo(bar)");
+    }
+
+    #[test]
+    fn equal_to() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::EqualTo,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).equals(2)");
+    }
+
+    #[test]
+    fn equal_to_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::EqualTo,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.equals(bar)");
+    }
+
+    #[test]
+    fn not_equal_to() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::NotEqualTo,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).notEquals(2)");
+    }
+
+    #[test]
+    fn not_equal_to_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::NotEqualTo,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.notEquals(bar)");
+    }
+
+    #[test]
+    fn less_than() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::LessThan,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).lessThan(2)");
+    }
+
+    #[test]
+    fn less_than_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::LessThan,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.lessThan(bar)");
+    }
+
+    #[test]
+    fn less_than_or_equal_to() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::LessThanOrEqualTo,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(
+            print_binary_operator(&expression),
+            "(1).lessThanOrEquals(2)"
+        );
+    }
+
+    #[test]
+    fn less_than_or_equal_to_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::LessThanOrEqualTo,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(
+            print_binary_operator(&expression),
+            "foo.lessThanOrEquals(bar)"
+        );
+    }
+
+    #[test]
+    fn greater_than() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::GreaterThan,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).greaterThan(2)");
+    }
+
+    #[test]
+    fn greater_than_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::GreaterThan,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.greaterThan(bar)");
+    }
+
+    #[test]
+    fn greater_than_or_equal_to() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::GreaterThanOrEqualTo,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(
+            print_binary_operator(&expression),
+            "(1).greaterThanOrEquals(2)"
+        );
+    }
+
+    #[test]
+    fn greater_than_or_equal_to_without_number_literals_do_not_have_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::GreaterThanOrEqualTo,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(
+            print_binary_operator(&expression),
+            "foo.greaterThanOrEquals(bar)"
+        );
+    }
+
+    #[test]
+    fn and() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::And,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "(foo&&bar)");
+    }
+
+    #[test]
+    fn or() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Or,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "(foo||bar)");
+    }
+
+    #[test]
+    fn method_lookup() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::MethodLookup,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.bar");
+    }
+
+    #[test]
+    fn wrap_left_in_parenthesis_if_left_is_integer_literal_in_method_lookup() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::MethodLookup,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::identifier_for_test("foo"),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).foo");
+    }
+
+    #[test]
+    fn field_lookup() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::FieldLookup,
+            left_child: ConcreteExpression::identifier_for_test("foo"),
+            right_child: ConcreteExpression::identifier_for_test("bar"),
+        };
+        assert_eq!(print_binary_operator(&expression), "foo.bar");
+    }
+
+    #[test]
+    fn wrap_left_in_parenthesis_if_left_is_integer_literal_in_field_lookup() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::FieldLookup,
+            left_child: ConcreteExpression::integer_for_test(1),
+            right_child: ConcreteExpression::identifier_for_test("foo"),
+        };
+        assert_eq!(print_binary_operator(&expression), "(1).foo");
+    }
+}

--- a/rust/js_backend/src/expression/block.rs
+++ b/rust/js_backend/src/expression/block.rs
@@ -1,0 +1,57 @@
+use typed_ast::ConcreteBlockExpression;
+
+pub fn print_block(block: &ConcreteBlockExpression) -> String {
+    if block.contents.is_empty() {
+        return String::new();
+    }
+    if block.contents.len() == 1 {
+        return super::print_expression(&block.contents[0]);
+    }
+    let mut result = String::new();
+    result.push_str("(()=>{");
+    for (index, expression) in block.contents.iter().enumerate() {
+        if index == &block.contents.len() - 1 {
+            result.push_str("return ");
+        }
+        result.push_str(super::print_expression(expression).as_str());
+        result.push(';');
+    }
+    result.push_str("})()");
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn an_empty_code_block_produces_an_empty_string() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![],
+        };
+        assert_eq!(print_block(&block), "");
+    }
+
+    #[test]
+    fn a_code_block_with_one_expression_produces_the_expression() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![ConcreteExpression::integer_for_test(42)],
+        };
+        assert_eq!(print_block(&block), "42");
+    }
+
+    #[test]
+    fn a_code_block_with_two_or_more_expressions_produces_an_immediately_invoked_function() {
+        let block = ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![
+                ConcreteExpression::integer_for_test(42),
+                ConcreteExpression::integer_for_test(43),
+            ],
+        };
+        assert_eq!(print_block(&block), "(()=>{42;return 43;})()");
+    }
+}

--- a/rust/js_backend/src/expression/boolean.rs
+++ b/rust/js_backend/src/expression/boolean.rs
@@ -1,0 +1,29 @@
+use typed_ast::ConcreteBooleanExpression;
+
+pub fn print_boolean(boolean: &ConcreteBooleanExpression) -> String {
+    boolean.value.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteBooleanExpression, ConcreteType, PrimitiveType};
+
+    #[test]
+    fn print_true() {
+        let boolean = ConcreteBooleanExpression {
+            expression_type: ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
+            value: true,
+        };
+        assert_eq!(print_boolean(&boolean), "true");
+    }
+
+    #[test]
+    fn print_false() {
+        let boolean = ConcreteBooleanExpression {
+            expression_type: ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
+            value: false,
+        };
+        assert_eq!(print_boolean(&boolean), "false");
+    }
+}

--- a/rust/js_backend/src/expression/function_declaration.rs
+++ b/rust/js_backend/src/expression/function_declaration.rs
@@ -1,0 +1,62 @@
+use typed_ast::ConcreteFunctionExpression;
+
+pub fn print_function_declaration(function: &ConcreteFunctionExpression) -> String {
+    let mut result = String::new();
+    result.push('(');
+    for (index, parameter) in function.argument_names.iter().enumerate() {
+        if index > 0 {
+            result.push(',');
+        }
+        result.push_str(parameter.as_str());
+    }
+    result.push_str(")=>(");
+    result.push_str(super::print_expression(&function.body).as_str());
+    result.push(')');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn prints_a_function_with_no_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec![],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "()=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_one_argument() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_two_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string(), "y".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y)=>(42)");
+    }
+
+    #[test]
+    fn prints_a_function_with_three_arguments() {
+        let function = ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            body: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_function_declaration(&function), "(x,y,z)=>(42)");
+    }
+}

--- a/rust/js_backend/src/expression/if_expression.rs
+++ b/rust/js_backend/src/expression/if_expression.rs
@@ -1,0 +1,65 @@
+use typed_ast::ConcreteIfExpression;
+
+fn print_true_path(expression: &ConcreteIfExpression) -> String {
+    let has_else = expression.path_if_false.is_some();
+    let mut result = String::new();
+    if !has_else {
+        result.push_str("[\"some\",");
+    }
+    result.push_str(super::print_expression(&expression.path_if_true).as_str());
+    if !has_else {
+        result.push(']');
+    }
+    result
+}
+
+fn print_false_path(expression: &ConcreteIfExpression) -> String {
+    expression
+        .path_if_false
+        .as_ref()
+        .map_or_else(|| "[\"none\"]".to_string(), super::print_expression)
+}
+
+pub fn print_if_expression(expression: &ConcreteIfExpression) -> String {
+    let mut result = String::new();
+    result.push('(');
+    result.push_str(super::print_expression(&expression.condition).as_str());
+    result.push('?');
+    result.push_str(print_true_path(expression).as_str());
+    result.push(':');
+    result.push_str(print_false_path(expression).as_str());
+    result.push(')');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use typed_ast::{ConcreteExpression, ConcreteIfExpression, ConcreteType};
+
+    use super::*;
+
+    #[test]
+    fn prints_if_with_all_paths() {
+        let expression = ConcreteIfExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            condition: ConcreteExpression::identifier_for_test("foo"),
+            path_if_true: ConcreteExpression::identifier_for_test("bar"),
+            path_if_false: Some(ConcreteExpression::identifier_for_test("baz")),
+        };
+        assert_eq!(print_if_expression(&expression), "(foo?bar:baz)");
+    }
+
+    #[test]
+    fn prints_if_with_only_true_path() {
+        let expression = ConcreteIfExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            condition: ConcreteExpression::identifier_for_test("foo"),
+            path_if_true: ConcreteExpression::identifier_for_test("bar"),
+            path_if_false: None,
+        };
+        assert_eq!(
+            print_if_expression(&expression),
+            "(foo?[\"some\",bar]:[\"none\"])"
+        );
+    }
+}

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -16,10 +16,7 @@ pub fn print_list(list: &ConcreteListExpression) -> String {
 
 #[cfg(test)]
 mod test {
-    use typed_ast::{
-        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
-        ConcreteType,
-    };
+    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
 
     use super::*;
 
@@ -28,14 +25,8 @@ mod test {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                })),
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 43,
-                })),
+                ConcreteExpression::integer_for_test(42),
+                ConcreteExpression::integer_for_test(43),
             ],
         };
         assert_eq!(print_list(&list), "[42,43]");
@@ -45,12 +36,7 @@ mod test {
     fn does_not_include_comma_with_one_item() {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
-            contents: vec![ConcreteExpression::Integer(Box::new(
-                ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                },
-            ))],
+            contents: vec![ConcreteExpression::integer_for_test(42)],
         };
         assert_eq!(print_list(&list), "[42]");
     }
@@ -60,14 +46,8 @@ mod test {
         let list = ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
             contents: vec![
-                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                    expression_type: ConcreteType::default_string_for_test(),
-                    value: "foo".to_string(),
-                })),
-                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                    expression_type: ConcreteType::default_string_for_test(),
-                    value: "bar".to_string(),
-                })),
+                ConcreteExpression::string_for_test("foo"),
+                ConcreteExpression::string_for_test("bar"),
             ],
         };
         assert_eq!(print_list(&list), "[\"foo\",\"bar\"]");

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -1,0 +1,75 @@
+use super::print_expression;
+use typed_ast::ConcreteListExpression;
+
+pub fn print_list(list: &ConcreteListExpression) -> String {
+    let mut result = String::new();
+    result.push('[');
+    for (index, item) in list.contents.iter().enumerate() {
+        result.push_str(&print_expression(item));
+        if index < list.contents.len() - 1 {
+            result.push(',');
+        }
+    }
+    result.push(']');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use typed_ast::{
+        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
+        ConcreteType,
+    };
+
+    use super::*;
+
+    #[test]
+    fn can_print_list_of_integers() {
+        let list = ConcreteListExpression {
+            expression_type: ConcreteType::default_list_for_test(),
+            contents: vec![
+                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    expression_type: ConcreteType::default_integer_for_test(),
+                    value: 42,
+                })),
+                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    expression_type: ConcreteType::default_integer_for_test(),
+                    value: 43,
+                })),
+            ],
+        };
+        assert_eq!(print_list(&list), "[42,43]");
+    }
+
+    #[test]
+    fn does_not_include_comma_with_one_item() {
+        let list = ConcreteListExpression {
+            expression_type: ConcreteType::default_list_for_test(),
+            contents: vec![ConcreteExpression::Integer(Box::new(
+                ConcreteIntegerLiteralExpression {
+                    expression_type: ConcreteType::default_integer_for_test(),
+                    value: 42,
+                },
+            ))],
+        };
+        assert_eq!(print_list(&list), "[42]");
+    }
+
+    #[test]
+    fn can_print_list_of_strings() {
+        let list = ConcreteListExpression {
+            expression_type: ConcreteType::default_list_for_test(),
+            contents: vec![
+                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                    expression_type: ConcreteType::default_string_for_test(),
+                    value: "foo".to_string(),
+                })),
+                ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                    expression_type: ConcreteType::default_string_for_test(),
+                    value: "bar".to_string(),
+                })),
+            ],
+        };
+        assert_eq!(print_list(&list), "[\"foo\",\"bar\"]");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,3 +1,4 @@
+mod binary_operator;
 mod list;
 mod record;
 
@@ -14,6 +15,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::StringLiteral(string) => print_string_literal(string),
         ConcreteExpression::Record(record) => record::print_record(record),
         ConcreteExpression::List(list) => list::print_list(list),
+        ConcreteExpression::BinaryOperator(operator) => {
+            binary_operator::print_binary_operator(operator)
+        }
         _ => unimplemented!(),
     }
 }
@@ -23,9 +27,10 @@ mod test {
     use std::collections::HashMap;
 
     use super::*;
+    use ast::BinaryOperatorSymbol;
     use typed_ast::{
-        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
-        ConcreteType,
+        ConcreteBinaryOperatorExpression, ConcreteListExpression, ConcreteRecordExpression,
+        ConcreteStringLiteralExpression, ConcreteType,
     };
 
     #[test]
@@ -76,5 +81,17 @@ mod test {
             contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
         assert_eq!(print_expression(&list), "[42]");
+    }
+
+    #[test]
+    fn print_binary_operator() {
+        let expression =
+            ConcreteExpression::BinaryOperator(Box::new(ConcreteBinaryOperatorExpression {
+                expression_type: ConcreteType::default_binary_operator_for_test(),
+                symbol: BinaryOperatorSymbol::FieldLookup,
+                left_child: ConcreteExpression::identifier_for_test("foo"),
+                right_child: ConcreteExpression::identifier_for_test("bar"),
+            }));
+        assert_eq!(print_expression(&expression), "foo.bar");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,3 +1,4 @@
+mod list;
 mod record;
 
 use crate::{
@@ -12,6 +13,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Integer(integer) => print_integer_literal(integer),
         ConcreteExpression::StringLiteral(string) => print_string_literal(string),
         ConcreteExpression::Record(record) => record::print_record(record),
+        ConcreteExpression::List(list) => list::print_list(list),
         _ => unimplemented!(),
     }
 }
@@ -22,8 +24,8 @@ mod test {
 
     use super::*;
     use typed_ast::{
-        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression, ConcreteRecordExpression,
-        ConcreteStringLiteralExpression, ConcreteType,
+        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression, ConcreteListExpression,
+        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteType,
     };
 
     #[test]
@@ -81,5 +83,19 @@ mod test {
             print_expression(&expression) == "{bar: \"baz\", foo: 42}"
                 || print_expression(&expression) == "{foo: 42, bar: \"baz\"}"
         );
+    }
+
+    #[test]
+    fn can_print_list() {
+        let list = ConcreteExpression::List(Box::new(ConcreteListExpression {
+            expression_type: ConcreteType::default_list_for_test(),
+            contents: vec![ConcreteExpression::Integer(Box::new(
+                ConcreteIntegerLiteralExpression {
+                    expression_type: ConcreteType::default_integer_for_test(),
+                    value: 42,
+                },
+            ))],
+        }));
+        assert_eq!(print_expression(&list), "[42]");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,0 +1,51 @@
+use crate::{
+    identifier::print_identifier,
+    literals::{print_integer_literal, print_string_literal},
+};
+use typed_ast::ConcreteExpression;
+
+pub fn print_expression(expression: &ConcreteExpression) -> String {
+    match expression {
+        ConcreteExpression::Identifier(identifier) => print_identifier(identifier),
+        ConcreteExpression::Integer(integer) => print_integer_literal(integer),
+        ConcreteExpression::StringLiteral(string) => print_string_literal(string),
+        _ => unimplemented!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::{
+        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression,
+        ConcreteStringLiteralExpression, ConcreteType,
+    };
+
+    #[test]
+    fn can_print_identifier() {
+        let expression = ConcreteExpression::Identifier(Box::new(ConcreteIdentifierExpression {
+            expression_type: ConcreteType::default_for_test(),
+            name: "foo".to_string(),
+        }));
+        assert_eq!(print_expression(&expression), "foo");
+    }
+
+    #[test]
+    fn can_print_integer_literal() {
+        let expression = ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+            expression_type: ConcreteType::default_for_test(),
+            value: 42,
+        }));
+        assert_eq!(print_expression(&expression), "42");
+    }
+
+    #[test]
+    fn can_print_string_literal() {
+        let expression =
+            ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                expression_type: ConcreteType::default_for_test(),
+                value: "foo".to_string(),
+            }));
+        assert_eq!(print_expression(&expression), "\"foo\"");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,5 +1,6 @@
 mod binary_operator;
 mod block;
+mod boolean;
 mod function_declaration;
 mod if_expression;
 mod list;
@@ -32,7 +33,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Function(function) => {
             function_declaration::print_function_declaration(function)
         }
-        ConcreteExpression::Boolean(_) => unimplemented!(),
+        ConcreteExpression::Boolean(boolean) => boolean::print_boolean(boolean),
     }
 }
 
@@ -43,10 +44,10 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteFunctionExpression,
-        ConcreteIfExpression, ConcreteListExpression, ConcreteRecordExpression,
-        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
-        ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteBooleanExpression,
+        ConcreteFunctionExpression, ConcreteIfExpression, ConcreteListExpression,
+        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteTagExpression,
+        ConcreteType, ConcreteUnaryOperatorExpression, PrimitiveType,
     };
 
     #[test]
@@ -160,5 +161,14 @@ mod test {
             body: ConcreteExpression::integer_for_test(42),
         }));
         assert_eq!(print_expression(&function), "()=>(42)");
+    }
+
+    #[test]
+    fn print_boolean() {
+        let boolean = ConcreteExpression::Boolean(Box::new(ConcreteBooleanExpression {
+            expression_type: ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
+            value: true,
+        }));
+        assert_eq!(print_expression(&boolean), "true");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,6 +1,7 @@
 mod binary_operator;
 mod list;
 mod record;
+mod unary_operator;
 
 use crate::{
     identifier::print_identifier,
@@ -18,6 +19,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::BinaryOperator(operator) => {
             binary_operator::print_binary_operator(operator)
         }
+        ConcreteExpression::UnaryOperator(operator) => {
+            unary_operator::print_unary_operator(operator)
+        }
         _ => unimplemented!(),
     }
 }
@@ -27,10 +31,10 @@ mod test {
     use std::collections::HashMap;
 
     use super::*;
-    use ast::BinaryOperatorSymbol;
+    use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
         ConcreteBinaryOperatorExpression, ConcreteListExpression, ConcreteRecordExpression,
-        ConcreteStringLiteralExpression, ConcreteType,
+        ConcreteStringLiteralExpression, ConcreteType, ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -93,5 +97,16 @@ mod test {
                 right_child: ConcreteExpression::identifier_for_test("bar"),
             }));
         assert_eq!(print_expression(&expression), "foo.bar");
+    }
+
+    #[test]
+    fn can_print_unary_operator() {
+        let expression =
+            ConcreteExpression::UnaryOperator(Box::new(ConcreteUnaryOperatorExpression {
+                expression_type: ConcreteType::default_integer_for_test(),
+                symbol: UnaryOperatorSymbol::Negative,
+                child: ConcreteExpression::integer_for_test(42),
+            }));
+        assert_eq!(print_expression(&expression), "-42");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,4 +1,5 @@
 mod binary_operator;
+mod block;
 mod if_expression;
 mod list;
 mod record;
@@ -26,6 +27,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         }
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
+        ConcreteExpression::Block(block) => block::print_block(block),
         _ => unimplemented!(),
     }
 }
@@ -37,9 +39,9 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteIfExpression, ConcreteListExpression,
-        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteTagExpression,
-        ConcreteType, ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteIfExpression,
+        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
+        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -134,5 +136,14 @@ mod test {
             path_if_false: Some(ConcreteExpression::identifier_for_test("baz")),
         }));
         assert_eq!(print_expression(&expression), "(foo?bar:baz)");
+    }
+
+    #[test]
+    fn print_block() {
+        let block = ConcreteExpression::Block(Box::new(ConcreteBlockExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            contents: vec![ConcreteExpression::integer_for_test(42)],
+        }));
+        assert_eq!(print_expression(&block), "42");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,5 +1,6 @@
 mod binary_operator;
 mod block;
+mod function_declaration;
 mod if_expression;
 mod list;
 mod record;
@@ -28,7 +29,10 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
         ConcreteExpression::Block(block) => block::print_block(block),
-        _ => unimplemented!(),
+        ConcreteExpression::Function(function) => {
+            function_declaration::print_function_declaration(function)
+        }
+        ConcreteExpression::Boolean(_) => unimplemented!(),
     }
 }
 
@@ -39,9 +43,10 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteIfExpression,
-        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
-        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteFunctionExpression,
+        ConcreteIfExpression, ConcreteListExpression, ConcreteRecordExpression,
+        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
+        ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -145,5 +150,15 @@ mod test {
             contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
         assert_eq!(print_expression(&block), "42");
+    }
+
+    #[test]
+    fn print_function_declaration() {
+        let function = ConcreteExpression::Function(Box::new(ConcreteFunctionExpression {
+            expression_type: ConcreteType::default_function_for_test(),
+            argument_names: vec![],
+            body: ConcreteExpression::integer_for_test(42),
+        }));
+        assert_eq!(print_expression(&function), "()=>(42)");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,3 +1,5 @@
+mod record;
+
 use crate::{
     identifier::print_identifier,
     literals::{print_integer_literal, print_string_literal},
@@ -9,15 +11,18 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Identifier(identifier) => print_identifier(identifier),
         ConcreteExpression::Integer(integer) => print_integer_literal(integer),
         ConcreteExpression::StringLiteral(string) => print_string_literal(string),
+        ConcreteExpression::Record(record) => record::print_record(record),
         _ => unimplemented!(),
     }
 }
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::*;
     use typed_ast::{
-        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression,
+        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression, ConcreteRecordExpression,
         ConcreteStringLiteralExpression, ConcreteType,
     };
 
@@ -47,5 +52,34 @@ mod test {
                 value: "foo".to_string(),
             }));
         assert_eq!(print_expression(&expression), "\"foo\"");
+    }
+
+    #[test]
+    fn can_print_record() {
+        let expression = ConcreteExpression::Record(Box::new(ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([
+                (
+                    "foo".to_string(),
+                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                        expression_type: ConcreteType::default_integer_for_test(),
+                        value: 42,
+                    })),
+                ),
+                (
+                    "bar".to_string(),
+                    ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                        expression_type: ConcreteType::default_string_for_test(),
+                        value: "baz".to_string(),
+                    })),
+                ),
+            ]),
+        }));
+        // Because of the HashMap, the order of the keys is not guaranteed.
+        // However, the order doesn't matter so we can accept either one.
+        assert!(
+            print_expression(&expression) == "{bar: \"baz\", foo: 42}"
+                || print_expression(&expression) == "{foo: 42, bar: \"baz\"}"
+        );
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -24,35 +24,25 @@ mod test {
 
     use super::*;
     use typed_ast::{
-        ConcreteIdentifierExpression, ConcreteIntegerLiteralExpression, ConcreteListExpression,
-        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteType,
+        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
+        ConcreteType,
     };
 
     #[test]
     fn can_print_identifier() {
-        let expression = ConcreteExpression::Identifier(Box::new(ConcreteIdentifierExpression {
-            expression_type: ConcreteType::default_for_test(),
-            name: "foo".to_string(),
-        }));
+        let expression = ConcreteExpression::identifier_for_test("foo");
         assert_eq!(print_expression(&expression), "foo");
     }
 
     #[test]
     fn can_print_integer_literal() {
-        let expression = ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-            expression_type: ConcreteType::default_for_test(),
-            value: 42,
-        }));
+        let expression = ConcreteExpression::integer_for_test(42);
         assert_eq!(print_expression(&expression), "42");
     }
 
     #[test]
     fn can_print_string_literal() {
-        let expression =
-            ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                expression_type: ConcreteType::default_for_test(),
-                value: "foo".to_string(),
-            }));
+        let expression = ConcreteExpression::string_for_test("foo");
         assert_eq!(print_expression(&expression), "\"foo\"");
     }
 
@@ -61,13 +51,7 @@ mod test {
         let expression = ConcreteExpression::Record(Box::new(ConcreteRecordExpression {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([
-                (
-                    "foo".to_string(),
-                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                        expression_type: ConcreteType::default_integer_for_test(),
-                        value: 42,
-                    })),
-                ),
+                ("foo".to_string(), ConcreteExpression::integer_for_test(42)),
                 (
                     "bar".to_string(),
                     ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
@@ -89,12 +73,7 @@ mod test {
     fn can_print_list() {
         let list = ConcreteExpression::List(Box::new(ConcreteListExpression {
             expression_type: ConcreteType::default_list_for_test(),
-            contents: vec![ConcreteExpression::Integer(Box::new(
-                ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                },
-            ))],
+            contents: vec![ConcreteExpression::integer_for_test(42)],
         }));
         assert_eq!(print_expression(&list), "[42]");
     }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,4 +1,5 @@
 mod binary_operator;
+mod if_expression;
 mod list;
 mod record;
 mod tag;
@@ -24,6 +25,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
             unary_operator::print_unary_operator(operator)
         }
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
+        ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
         _ => unimplemented!(),
     }
 }
@@ -35,9 +37,9 @@ mod test {
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
-        ConcreteBinaryOperatorExpression, ConcreteListExpression, ConcreteRecordExpression,
-        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
-        ConcreteUnaryOperatorExpression,
+        ConcreteBinaryOperatorExpression, ConcreteIfExpression, ConcreteListExpression,
+        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteTagExpression,
+        ConcreteType, ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -121,5 +123,16 @@ mod test {
             contents: vec![],
         }));
         assert_eq!(print_expression(&tag), "\"foo\"");
+    }
+
+    #[test]
+    fn print_if_expression() {
+        let expression = ConcreteExpression::If(Box::new(ConcreteIfExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            condition: ConcreteExpression::identifier_for_test("foo"),
+            path_if_true: ConcreteExpression::identifier_for_test("bar"),
+            path_if_false: Some(ConcreteExpression::identifier_for_test("baz")),
+        }));
+        assert_eq!(print_expression(&expression), "(foo?bar:baz)");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,6 +1,7 @@
 mod binary_operator;
 mod list;
 mod record;
+mod tag;
 mod unary_operator;
 
 use crate::{
@@ -22,6 +23,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::UnaryOperator(operator) => {
             unary_operator::print_unary_operator(operator)
         }
+        ConcreteExpression::Tag(tag) => tag::print_tag(tag),
         _ => unimplemented!(),
     }
 }
@@ -34,7 +36,8 @@ mod test {
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
         ConcreteBinaryOperatorExpression, ConcreteListExpression, ConcreteRecordExpression,
-        ConcreteStringLiteralExpression, ConcreteType, ConcreteUnaryOperatorExpression,
+        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
+        ConcreteUnaryOperatorExpression,
     };
 
     #[test]
@@ -108,5 +111,15 @@ mod test {
                 child: ConcreteExpression::integer_for_test(42),
             }));
         assert_eq!(print_expression(&expression), "-42");
+    }
+
+    #[test]
+    fn print_tag() {
+        let tag = ConcreteExpression::Tag(Box::new(ConcreteTagExpression {
+            name: "foo".to_string(),
+            expression_type: ConcreteType::default_tag_union_for_test(false),
+            contents: vec![],
+        }));
+        assert_eq!(print_expression(&tag), "\"foo\"");
     }
 }

--- a/rust/js_backend/src/expression/record.rs
+++ b/rust/js_backend/src/expression/record.rs
@@ -21,29 +21,17 @@ mod test {
     use std::collections::HashMap;
 
     use super::*;
-    use typed_ast::{
-        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
-        ConcreteType,
-    };
+    use typed_ast::{ConcreteExpression, ConcreteType};
 
     #[test]
     fn can_print_record() {
         let record = ConcreteRecordExpression {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([
-                (
-                    "foo".to_string(),
-                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                        expression_type: ConcreteType::default_integer_for_test(),
-                        value: 42,
-                    })),
-                ),
+                ("foo".to_string(), ConcreteExpression::integer_for_test(42)),
                 (
                     "bar".to_string(),
-                    ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
-                        expression_type: ConcreteType::default_string_for_test(),
-                        value: "baz".to_string(),
-                    })),
+                    ConcreteExpression::string_for_test("baz"),
                 ),
             ]),
         };
@@ -61,10 +49,7 @@ mod test {
             expression_type: ConcreteType::default_record_for_test(),
             contents: HashMap::from([(
                 "foo".to_string(),
-                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
-                    expression_type: ConcreteType::default_integer_for_test(),
-                    value: 42,
-                })),
+                ConcreteExpression::integer_for_test(42),
             )]),
         };
         assert_eq!(print_record(&record), "{foo: 42}");

--- a/rust/js_backend/src/expression/record.rs
+++ b/rust/js_backend/src/expression/record.rs
@@ -1,0 +1,72 @@
+use super::print_expression;
+use typed_ast::ConcreteRecordExpression;
+
+pub fn print_record(record: &ConcreteRecordExpression) -> String {
+    let mut result = String::new();
+    result.push('{');
+    for (index, (key, value)) in record.contents.iter().enumerate() {
+        result.push_str(key);
+        result.push_str(": ");
+        result.push_str(&print_expression(value));
+        if index < record.contents.len() - 1 {
+            result.push_str(", ");
+        }
+    }
+    result.push('}');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::*;
+    use typed_ast::{
+        ConcreteExpression, ConcreteIntegerLiteralExpression, ConcreteStringLiteralExpression,
+        ConcreteType,
+    };
+
+    #[test]
+    fn can_print_record() {
+        let record = ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([
+                (
+                    "foo".to_string(),
+                    ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                        expression_type: ConcreteType::default_integer_for_test(),
+                        value: 42,
+                    })),
+                ),
+                (
+                    "bar".to_string(),
+                    ConcreteExpression::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+                        expression_type: ConcreteType::default_string_for_test(),
+                        value: "baz".to_string(),
+                    })),
+                ),
+            ]),
+        };
+        // Because of the HashMap, the order of the keys is not guaranteed.
+        // However, the order doesn't matter so we can accept either one.
+        assert!(
+            print_record(&record) == "{bar: \"baz\", foo: 42}"
+                || print_record(&record) == "{foo: 42, bar: \"baz\"}"
+        );
+    }
+
+    #[test]
+    fn does_not_include_comma_with_one_item() {
+        let record = ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([(
+                "foo".to_string(),
+                ConcreteExpression::Integer(Box::new(ConcreteIntegerLiteralExpression {
+                    expression_type: ConcreteType::default_integer_for_test(),
+                    value: 42,
+                })),
+            )]),
+        };
+        assert_eq!(print_record(&record), "{foo: 42}");
+    }
+}

--- a/rust/js_backend/src/expression/tag.rs
+++ b/rust/js_backend/src/expression/tag.rs
@@ -1,0 +1,66 @@
+use typed_ast::{ConcreteTagExpression, ConcreteType};
+
+pub fn print_tag(tag: &ConcreteTagExpression) -> String {
+    let some_tags_have_content;
+    if let ConcreteType::TagUnion(tag_union_type) = &tag.expression_type {
+        some_tags_have_content = tag_union_type.some_tags_have_content;
+    } else {
+        panic!("Expected tag to have tag union type");
+    }
+    if some_tags_have_content {
+        let mut output = String::new();
+        output.push_str("[\"");
+        output.push_str(&tag.name);
+        output.push('"');
+        if !tag.contents.is_empty() {
+            let contents = tag
+                .contents
+                .iter()
+                .map(super::print_expression)
+                .collect::<Vec<_>>()
+                .join(", ");
+            output.push(',');
+            output.push_str(&contents);
+        }
+        output.push(']');
+        output
+    } else {
+        format!("\"{}\"", tag.name)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::ConcreteExpression;
+
+    #[test]
+    fn tags_in_tag_unions_without_contents_are_strings() {
+        let tag = ConcreteTagExpression {
+            name: "foo".to_string(),
+            expression_type: ConcreteType::default_tag_union_for_test(false),
+            contents: vec![],
+        };
+        assert_eq!(print_tag(&tag), "\"foo\"");
+    }
+
+    #[test]
+    fn tags_without_contents_are_arrays_when_some_tags_have_content() {
+        let tag = ConcreteTagExpression {
+            name: "foo".to_string(),
+            expression_type: ConcreteType::default_tag_union_for_test(true),
+            contents: vec![],
+        };
+        assert_eq!(print_tag(&tag), "[\"foo\"]");
+    }
+
+    #[test]
+    fn tags_with_contents_are_arrays_when_some_tags_have_content() {
+        let tag = ConcreteTagExpression {
+            name: "foo".to_string(),
+            expression_type: ConcreteType::default_tag_union_for_test(true),
+            contents: vec![ConcreteExpression::integer_for_test(42)],
+        };
+        assert_eq!(print_tag(&tag), "[\"foo\",42]");
+    }
+}

--- a/rust/js_backend/src/expression/unary_operator.rs
+++ b/rust/js_backend/src/expression/unary_operator.rs
@@ -1,0 +1,44 @@
+use ast::UnaryOperatorSymbol;
+use typed_ast::ConcreteUnaryOperatorExpression;
+
+fn print_unary_operator_symbol(operator: &UnaryOperatorSymbol) -> String {
+    match operator {
+        UnaryOperatorSymbol::Negative => "-".to_string(),
+        UnaryOperatorSymbol::Not => "!".to_string(),
+    }
+}
+
+pub fn print_unary_operator(expression: &ConcreteUnaryOperatorExpression) -> String {
+    format!(
+        "{}{}",
+        print_unary_operator_symbol(&expression.symbol),
+        super::print_expression(&expression.child)
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ast::UnaryOperatorSymbol;
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    #[test]
+    fn can_print_negative_integer() {
+        let expression = ConcreteUnaryOperatorExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            symbol: UnaryOperatorSymbol::Negative,
+            child: ConcreteExpression::integer_for_test(42),
+        };
+        assert_eq!(print_unary_operator(&expression), "-42");
+    }
+
+    #[test]
+    fn can_print_not_boolean() {
+        let expression = ConcreteUnaryOperatorExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            symbol: UnaryOperatorSymbol::Not,
+            child: ConcreteExpression::identifier_for_test("foo"),
+        };
+        assert_eq!(print_unary_operator(&expression), "!foo");
+    }
+}

--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -1,2 +1,3 @@
+mod expression;
 mod identifier;
 mod literals;

--- a/rust/js_backend/src/literals/mod.rs
+++ b/rust/js_backend/src/literals/mod.rs
@@ -1,2 +1,5 @@
 mod integer;
 mod string;
+
+pub use integer::print_integer_literal;
+pub use string::print_string_literal;

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 ast = { path = "../ast" }
-nom = "7.1.3"
+nom.workspace = true

--- a/rust/parser/src/document.rs
+++ b/rust/parser/src/document.rs
@@ -21,9 +21,7 @@ enum DocumentElement<'a> {
     Expression(Expression<'a>),
 }
 
-pub fn document<'a>(
-    context: ExpressionContext,
-) -> impl FnMut(ParserInput<'a>) -> IResult<'a, DocumentNode<'a>> {
+pub fn document<'a>() -> impl FnMut(ParserInput<'a>) -> IResult<'a, DocumentNode<'a>> {
     map(
         consumed(many0(alt((
             map(
@@ -79,7 +77,7 @@ mod test {
     #[test]
     fn blank_document_is_document() {
         let input = ParserInput::new("");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -87,7 +85,7 @@ mod test {
     #[test]
     fn import_is_document() {
         let input = ParserInput::new("import a from \"file.buri\"");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -95,7 +93,7 @@ mod test {
     #[test]
     fn import_value_is_preserved() {
         let input = ParserInput::new("import a from \"file.buri\"");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.imports.len(), 1);
         assert!(matches!(
@@ -113,7 +111,7 @@ mod test {
     #[test]
     fn type_declaration_is_document() {
         let input = ParserInput::new("Hello = World");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -121,7 +119,7 @@ mod test {
     #[test]
     fn type_declaration_value_is_preserved() {
         let input = ParserInput::new("Hello = World");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.type_declarations.len(), 1);
         assert_eq!(
@@ -140,7 +138,7 @@ mod test {
     #[test]
     fn literal_is_document() {
         let input = ParserInput::new("0");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -148,7 +146,7 @@ mod test {
     #[test]
     fn literal_value_is_preserved() {
         let input = ParserInput::new("314");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.expressions.len(), 1);
         assert!(matches!(
@@ -160,7 +158,7 @@ mod test {
     #[test]
     fn identifier_is_document() {
         let input = ParserInput::new("hello");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -168,7 +166,7 @@ mod test {
     #[test]
     fn variable_declaration_is_document() {
         let input = ParserInput::new("hello = world");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -176,7 +174,7 @@ mod test {
     #[test]
     fn function_call_is_document() {
         let input = ParserInput::new("main()");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -184,7 +182,7 @@ mod test {
     #[test]
     fn variable_declaration_value_is_preserved() {
         let input = ParserInput::new("hello = world");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (_, parsed) = result.unwrap();
         assert_eq!(parsed.value.variable_declarations.len(), 1);
         assert_eq!(
@@ -204,7 +202,7 @@ mod test {
     #[test]
     fn document_can_contain_multiple_lines_of_different_types() {
         let input = ParserInput::new("import a from \"file.buri\"\nHello = World\na");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }
@@ -212,7 +210,7 @@ mod test {
     #[test]
     fn document_can_contain_empty_lines() {
         let input = ParserInput::new("import a from \"file.buri\"\n\na");
-        let result = document(ExpressionContext::new())(input);
+        let result = document()(input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
     }

--- a/rust/parser/src/list.rs
+++ b/rust/parser/src/list.rs
@@ -10,7 +10,7 @@ use nom::{
     sequence::{delimited, preceded, terminated, tuple},
 };
 
-fn padded_expression<'a>(input: ParserInput<'a>) -> IResult<'a, Expression<'a>> {
+fn padded_expression(input: ParserInput) -> IResult<Expression> {
     preceded(
         opt(intra_expression_whitespace(
             ExpressionContext::new().allow_newlines_in_expressions(),
@@ -19,7 +19,7 @@ fn padded_expression<'a>(input: ParserInput<'a>) -> IResult<'a, Expression<'a>> 
     )(input)
 }
 
-fn padded_comma<'a>(input: ParserInput<'a>) -> IResult<'a, ParserInput<'a>> {
+fn padded_comma(input: ParserInput) -> IResult<ParserInput> {
     preceded(
         opt(intra_expression_whitespace(
             ExpressionContext::new().allow_newlines_in_expressions(),
@@ -28,7 +28,7 @@ fn padded_comma<'a>(input: ParserInput<'a>) -> IResult<'a, ParserInput<'a>> {
     )(input)
 }
 
-fn list_contents<'a>(input: ParserInput<'a>) -> IResult<'a, Vec<Expression<'a>>> {
+fn list_contents(input: ParserInput) -> IResult<Vec<Expression>> {
     map(
         tuple((
             padded_expression,
@@ -44,7 +44,7 @@ fn list_contents<'a>(input: ParserInput<'a>) -> IResult<'a, Vec<Expression<'a>>>
     )(input)
 }
 
-pub fn list<'a>(input: ParserInput<'a>) -> IResult<'a, ListNode<'a>> {
+pub fn list(input: ParserInput) -> IResult<ListNode> {
     map(
         consumed(delimited(
             tag("["),

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -20,3 +20,29 @@ pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
+
+impl ConcreteExpression {
+    #[must_use]
+    pub fn identifier_for_test(name: &str) -> Self {
+        Self::Identifier(Box::new(ConcreteIdentifierExpression {
+            expression_type: ConcreteType::default_for_test(),
+            name: name.to_string(),
+        }))
+    }
+
+    #[must_use]
+    pub fn string_for_test(string: &str) -> Self {
+        Self::StringLiteral(Box::new(ConcreteStringLiteralExpression {
+            expression_type: ConcreteType::default_string_for_test(),
+            value: string.to_string(),
+        }))
+    }
+
+    #[must_use]
+    pub fn integer_for_test(int: u64) -> Self {
+        Self::Integer(Box::new(ConcreteIntegerLiteralExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            value: int,
+        }))
+    }
+}

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -92,4 +92,12 @@ impl ConcreteType {
             tag_types: HashMap::new(),
         }))
     }
+
+    #[must_use]
+    pub fn default_function_for_test() -> Self {
+        Self::Function(Box::new(ConcreteFunctionType {
+            argument_types: vec![],
+            return_type: None,
+        }))
+    }
 }

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -72,4 +72,12 @@ impl ConcreteType {
             element_type: Self::default_string_for_test(),
         }))
     }
+
+    #[must_use]
+    pub fn default_binary_operator_for_test() -> Self {
+        Self::Function(Box::new(ConcreteFunctionType {
+            argument_types: vec![],
+            return_type: None,
+        }))
+    }
 }

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -21,6 +21,10 @@ pub struct ConcreteTagUnionType {
     /// Map the name of a tag to an array of the types of its contained values.
     /// Tag with no contents maps to empty vec.
     pub tag_types: HashMap<String, Vec<ConcreteType>>,
+    /// Signifies of any tags in the tag union have content. If this is true,
+    /// then at least one tag in the tag union has content. If this is false,
+    /// then no tags in the tag union have content.
+    pub some_tags_have_content: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -65,4 +65,11 @@ impl ConcreteType {
     pub const fn default_string_for_test() -> Self {
         Self::Primitive(PrimitiveType::Str)
     }
+
+    #[must_use]
+    pub fn default_list_for_test() -> Self {
+        Self::List(Box::new(ConcreteListType {
+            element_type: Self::default_string_for_test(),
+        }))
+    }
 }

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -42,3 +42,10 @@ pub enum ConcreteType {
     List(Box<ConcreteListType>),
     Record(Box<ConcreteRecordType>),
 }
+
+impl ConcreteType {
+    #[must_use]
+    pub const fn default_for_test() -> Self {
+        Self::Primitive(PrimitiveType::Str)
+    }
+}

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -46,6 +46,23 @@ pub enum ConcreteType {
 impl ConcreteType {
     #[must_use]
     pub const fn default_for_test() -> Self {
+        Self::default_string_for_test()
+    }
+
+    #[must_use]
+    pub fn default_record_for_test() -> Self {
+        Self::Record(Box::new(ConcreteRecordType {
+            field_types: HashMap::new(),
+        }))
+    }
+
+    #[must_use]
+    pub const fn default_integer_for_test() -> Self {
+        Self::Primitive(PrimitiveType::Num)
+    }
+
+    #[must_use]
+    pub const fn default_string_for_test() -> Self {
         Self::Primitive(PrimitiveType::Str)
     }
 }

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -84,4 +84,12 @@ impl ConcreteType {
             return_type: None,
         }))
     }
+
+    #[must_use]
+    pub fn default_tag_union_for_test(some_tags_have_content: bool) -> Self {
+        Self::TagUnion(Box::new(ConcreteTagUnionType {
+            some_tags_have_content,
+            tag_types: HashMap::new(),
+        }))
+    }
 }


### PR DESCRIPTION
This PR adds a GitHub action that will remove stale branches automatically. [Look at the marketplace to learn more about this action](https://github.com/marketplace/actions/remove-stale-branches).

Why do this?

When you merge stacked PRs through Aviator, only the final PR's branch is deleted. The rest are not. This means that unless those branches get cleaned up, they'll stick around forever. As we continue to work on Buri, it'll become increasingly likely that we'll want to use that branch name again.

So this PR will just help with cleaning up those stale branches automatically.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-boolean","parentHead":"c104e71dd3accda7d2cc656efd430dacbb782f37","parentPull":43,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-boolean","parentHead":"c104e71dd3accda7d2cc656efd430dacbb782f37","parentPull":43,"trunk":"main"}
```
-->
