### PR TITLE
Disambiguate tag constraints

### DIFF
--- a/rust/type_checker/src/constraints.rs
+++ b/rust/type_checker/src/constraints.rs
@@ -1,12 +1,22 @@
 use crate::GenericTypeId;
+use std::collections::HashMap;
 use typed_ast::ConcreteType;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Constrain that a generic type be a tag union with a tag named `tag_name`,
-/// the contents of which have the types of `tag_contents_types`.
-pub struct SubTagConstraint {
+/// Constrain that a generic type is a tag union
+/// with a tag of given name whose payload has particular types.
+pub struct HasTagConstraint {
     pub tag_name: String,
     pub tag_content_types: Vec<GenericTypeId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Constraint that a generic type is a tag union whose tags are a subset
+/// of a given set of tags.
+pub struct TagAtMostConstraint {
+    /// The keys are the names of the tags in a tag union.
+    /// The values are the types of the tag payloads.
+    pub tags: HashMap<String, Vec<GenericTypeId>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,9 +39,12 @@ pub struct HasMethodConstraint {
 pub enum Constraint {
     /// Constrain that a generic type be equal to some concrete type.
     EqualToConcrete(ConcreteType),
-    // Constrain that a generic type is a list whose contents have a particular type.
+    /// Constrain that a generic type is a list whose contents have a particular type.
     ListOfType(GenericTypeId),
-    SubTag(SubTagConstraint),
+    /// Constrain that a generic type is a tag union with at least a given set of tags.
+    HasTag(HasTagConstraint),
+    /// Constrain that a generic type is a tag union with at most a given set of tags.
+    TagAtMost(TagAtMostConstraint),
     HasField(HasFieldConstraint),
     HasMethod(HasMethodConstraint),
     /// Constrain that a generic type is a function with a given return type.

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -208,11 +208,10 @@ mod test {
             &mut substitutions,
             expression,
         );
-        match result.unwrap() {
-            GenericExpression::Block(block_expression) => {
-                assert_eq!((*block_expression).contents.len(), 3);
-            }
-            _ => panic!("Expected Block"),
+        if let Ok(GenericExpression::Block(block_expression)) = result {
+            assert_eq!((*block_expression).contents.len(), 3);
+        } else {
+            panic!();
         }
     }
 
@@ -324,11 +323,10 @@ mod test {
             &mut substitutions,
             expression,
         );
-        match result.unwrap() {
-            GenericExpression::Integer(integer_expression) => {
-                assert_eq!((*integer_expression).value, 314);
-            }
-            _ => panic!("Expected Integer"),
+        if let Ok(GenericExpression::Integer(integer_expression)) = result {
+            assert_eq!((*integer_expression).value, 314);
+        } else {
+            panic!();
         }
     }
 
@@ -416,11 +414,10 @@ mod test {
             &mut substitutions,
             expression,
         );
-        match result.unwrap() {
-            GenericExpression::List(list_node) => {
-                assert_eq!((*list_node).contents.len(), 3);
-            }
-            _ => panic!("Expected list"),
+        if let Ok(GenericExpression::List(list_node)) = result {
+            assert_eq!((*list_node).contents.len(), 3);
+        } else {
+            panic!();
         }
     }
 
@@ -498,11 +495,10 @@ mod test {
             &mut substitutions,
             expression,
         );
-        match result.unwrap() {
-            GenericExpression::StringLiteral(string_literal_expression) => {
-                assert_eq!((*string_literal_expression).value, "hello");
-            }
-            _ => panic!("Expected StringLiteral"),
+        if let Ok(GenericExpression::StringLiteral(string_literal_expression)) = result {
+            assert_eq!((*string_literal_expression).value, "hello");
+        } else {
+            panic!();
         }
     }
 }

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -47,11 +47,9 @@ fn translate_integer<'a>(
 ) -> GenericIntegerLiteralExpression<'a> {
     let type_id = schema.make_id();
     substitutions.insert_new_id(type_id);
-    schema.constraints.insert(
+    schema.insert(
         type_id,
-        vec![Constraint::EqualToConcrete(ConcreteType::Primitive(
-            PrimitiveType::Num,
-        ))],
+        Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Num)),
     );
     GenericIntegerLiteralExpression {
         expression_type: GenericSourcedType {
@@ -71,9 +69,7 @@ fn translate_list<'a>(
     substitutions.insert_new_id(list_type_id);
     let element_type_id = schema.make_id();
     substitutions.insert_new_id(element_type_id);
-    schema
-        .constraints
-        .insert(list_type_id, vec![Constraint::ListOfType(element_type_id)]);
+    schema.insert(list_type_id, Constraint::ListOfType(element_type_id));
     let mut element_translations = Vec::new();
     element_translations.reserve_exact(node.value.len());
     for element in node.value {
@@ -98,11 +94,9 @@ fn translate_string<'a>(
 ) -> GenericStringLiteralExpression<'a> {
     let type_id = schema.make_id();
     substitutions.insert_new_id(type_id);
-    schema.constraints.insert(
+    schema.insert(
         type_id,
-        vec![Constraint::EqualToConcrete(ConcreteType::Primitive(
-            PrimitiveType::Str,
-        ))],
+        Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Str)),
     );
     GenericStringLiteralExpression {
         expression_type: GenericSourcedType {

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -22,4 +22,15 @@ impl TypeSchema {
         self.next_id += 1;
         return_value
     }
+    /// Insert a new constraint for a given type.
+    pub fn insert(&mut self, typ: GenericTypeId, constraint: Constraint) {
+        match self.constraints.get_mut(&typ) {
+            Some(constraint_vec) => {
+                constraint_vec.push(constraint);
+            }
+            None => {
+                self.constraints.insert(typ, vec![constraint]);
+            }
+        }
+    }
 }

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -1,5 +1,7 @@
 use crate::{
-    constraints::{Constraint, HasFieldConstraint, HasMethodConstraint, SubTagConstraint},
+    constraints::{
+        Constraint, HasFieldConstraint, HasMethodConstraint, HasTagConstraint, TagAtMostConstraint,
+    },
     type_schema::TypeSchema,
     GenericTypeId,
 };
@@ -66,10 +68,21 @@ impl TypeSchemaSubstitutions {
             Constraint::ListOfType(element_type) => {
                 Constraint::ListOfType(self.get_canonical_id(element_type))
             }
-            Constraint::SubTag(sub_tag_constraint) => Constraint::SubTag(SubTagConstraint {
-                tag_name: sub_tag_constraint.tag_name,
-                tag_content_types: self.apply_to_vec(sub_tag_constraint.tag_content_types),
+            Constraint::HasTag(has_tag_constraint) => Constraint::HasTag(HasTagConstraint {
+                tag_name: has_tag_constraint.tag_name,
+                tag_content_types: self.apply_to_vec(has_tag_constraint.tag_content_types),
             }),
+            Constraint::TagAtMost(tag_at_most_constraint) => {
+                let mut new_constraint = TagAtMostConstraint {
+                    tags: HashMap::new(),
+                };
+                for (tag_name, tag_content_types) in tag_at_most_constraint.tags {
+                    new_constraint
+                        .tags
+                        .insert(tag_name, self.apply_to_vec(tag_content_types));
+                }
+                Constraint::TagAtMost(new_constraint)
+            }
             Constraint::HasField(has_field_constraint) => {
                 Constraint::HasField(HasFieldConstraint {
                     field_name: has_field_constraint.field_name,


### PR DESCRIPTION
`Constraint::SubTag(SubTagConstraint)` is ambiguous. It is not well defined what "subtype" means in the context of a tag union.

This PR splits this constraint into two new constraints, each with a well-defined interpretation.

`Constraint::HasTag(HasTagConstraint)` asserts that a type is a tag union and that the tag union has a tag with a specific name and specific content types.

`Constraint::TagAtMost(TagAtMostConstraint)` asserts that a type is a tag union, that the tag union does not have any tags beyond a specific set, and that the contents of the tags that are present in the tag union have certain types.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"insert_constraint","parentHead":"5cf650633f31202a17b39f61592fb228a1678315","parentPull":52,"trunk":"main"}
```
-->
