### PR TITLE
Add parsed unary operator to typed unary operator translator

### DIFF
--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -33,4 +33,12 @@ impl TypeSchema {
             }
         }
     }
+    /// Return the total number of constraints in the system.
+    pub fn number_of_constraints(&self) -> usize {
+        let mut constraint_count: usize = 0;
+        for constraint_vec in self.constraints.values() {
+            constraint_count += constraint_vec.len();
+        }
+        constraint_count
+    }
 }


### PR DESCRIPTION
Also fixes a bug in a few tests relating to how constraints are counted.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"constraint_helper_functions","parentHead":"5e2e3d50253ce1a714b49c90ab5479309e434d1f","parentPull":54,"trunk":"main"}
```
-->
