### PR TITLE
Add is_disregarded field to typed identifier

### DIFF
--- a/rust/js_backend/src/identifier.rs
+++ b/rust/js_backend/src/identifier.rs
@@ -14,6 +14,7 @@ mod test {
         let node = ConcreteIdentifierExpression {
             expression_type: ConcreteType::Primitive(PrimitiveType::Str),
             name: "foo".to_string(),
+            is_disregarded: false,
         };
         assert_eq!(print_identifier(&node), "foo");
     }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -27,6 +27,7 @@ impl ConcreteExpression {
         Self::Identifier(Box::new(ConcreteIdentifierExpression {
             expression_type: ConcreteType::default_for_test(),
             name: name.to_string(),
+            is_disregarded: false,
         }))
     }
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -35,6 +35,7 @@ pub struct TypedFunctionExpression<T> {
 pub struct TypedIdentifierExpression<T> {
     pub expression_type: T,
     pub name: String,
+    pub is_disregarded: bool,
 }
 
 // TODO(nick): add this to JS backend


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"translate_unary","parentHead":"b1e6a65e117ee7fd04b50fa8903a21f288d614b5","parentPull":55,"trunk":"main"}
```
-->
