### PR TITLE
Add parsed binary operator to typed binary operator translator

### DIFF
--- a/rust/js_backend/src/identifier.rs
+++ b/rust/js_backend/src/identifier.rs
@@ -14,6 +14,7 @@ mod test {
         let node = ConcreteIdentifierExpression {
             expression_type: ConcreteType::Primitive(PrimitiveType::Str),
             name: "foo".to_string(),
+            is_disregarded: false,
         };
         assert_eq!(print_identifier(&node), "foo");
     }

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -658,6 +658,31 @@ mod test {
     }
 
     #[test]
+    fn unary_operator_not_input_adds_three_constraints_beyond_those_added_by_the_child() {
+        let mut schema = TypeSchema::new();
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let expression = Expression::UnaryOperator(UnaryOperatorNode {
+            source: ParserInput::new(""),
+            value: UnaryOperatorValue {
+                symbol: UnaryOperatorSymbol::Not,
+                child: Box::new(Expression::Identifier(IdentifierNode {
+                    source: ParserInput::new(""),
+                    value: IdentifierValue {
+                        name: "hello".to_owned(),
+                        is_disregarded: false,
+                    },
+                })),
+            },
+        });
+        let _ = translate_parsed_expression_to_generic_expression(
+            &mut schema,
+            &mut substitutions,
+            expression,
+        );
+        assert_eq!(schema.number_of_constraints(), 3);
+    }
+
+    #[test]
     fn unary_operator_negative_input_preserves_symbol() {
         let mut schema = TypeSchema::new();
         let mut substitutions = TypeSchemaSubstitutions::new();
@@ -680,6 +705,38 @@ mod test {
             assert_eq!(
                 (*unary_operator_expression).symbol,
                 UnaryOperatorSymbol::Negative
+            )
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn unary_operator_not_input_preserves_symbol() {
+        let mut schema = TypeSchema::new();
+        let mut substitutions = TypeSchemaSubstitutions::new();
+        let expression = Expression::UnaryOperator(UnaryOperatorNode {
+            source: ParserInput::new(""),
+            value: UnaryOperatorValue {
+                symbol: UnaryOperatorSymbol::Not,
+                child: Box::new(Expression::Identifier(IdentifierNode {
+                    source: ParserInput::new(""),
+                    value: IdentifierValue {
+                        name: "hello".to_owned(),
+                        is_disregarded: false,
+                    },
+                })),
+            },
+        });
+        let result = translate_parsed_expression_to_generic_expression(
+            &mut schema,
+            &mut substitutions,
+            expression,
+        );
+        if let Ok(GenericExpression::UnaryOperator(unary_operator_expression)) = result {
+            assert_eq!(
+                (*unary_operator_expression).symbol,
+                UnaryOperatorSymbol::Not
             )
         } else {
             panic!();

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -1,5 +1,5 @@
 use crate::{
-    constraints::Constraint,
+    constraints::{Constraint, HasTagConstraint, TagAtMostConstraint},
     generic_nodes::{
         get_generic_type_id, GenericBlockExpression, GenericExpression,
         GenericIntegerLiteralExpression, GenericListExpression, GenericSourcedType,
@@ -9,7 +9,36 @@ use crate::{
     type_schema_substitutions::TypeSchemaSubstitutions,
 };
 use ast::{BlockNode, Expression, IntegerNode, ListNode, StringLiteralNode};
+use std::collections::HashMap;
 use typed_ast::{ConcreteType, PrimitiveType};
+
+const fn constrain_equal_to_num() -> Constraint {
+    Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Num))
+}
+
+const fn constrain_equal_to_str() -> Constraint {
+    Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Str))
+}
+
+fn constrain_at_least_true() -> Constraint {
+    Constraint::HasTag(HasTagConstraint {
+        tag_name: "true".to_owned(),
+        tag_content_types: vec![],
+    })
+}
+
+fn constrain_at_least_false() -> Constraint {
+    Constraint::HasTag(HasTagConstraint {
+        tag_name: "false".to_owned(),
+        tag_content_types: vec![],
+    })
+}
+
+fn constrain_at_most_boolean_tag() -> Constraint {
+    Constraint::TagAtMost(TagAtMostConstraint {
+        tags: HashMap::from([("true".to_owned(), vec![]), ("false".to_owned(), vec![])]),
+    })
+}
 
 fn translate_block<'a>(
     schema: &mut TypeSchema,
@@ -47,10 +76,7 @@ fn translate_integer<'a>(
 ) -> GenericIntegerLiteralExpression<'a> {
     let type_id = schema.make_id();
     substitutions.insert_new_id(type_id);
-    schema.insert(
-        type_id,
-        Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Num)),
-    );
+    schema.insert(type_id, constrain_equal_to_num());
     GenericIntegerLiteralExpression {
         expression_type: GenericSourcedType {
             type_id,
@@ -94,10 +120,7 @@ fn translate_string<'a>(
 ) -> GenericStringLiteralExpression<'a> {
     let type_id = schema.make_id();
     substitutions.insert_new_id(type_id);
-    schema.insert(
-        type_id,
-        Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Str)),
-    );
+    schema.insert(type_id, constrain_equal_to_str());
     GenericStringLiteralExpression {
         expression_type: GenericSourcedType {
             type_id,

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -33,4 +33,12 @@ impl TypeSchema {
             }
         }
     }
+    /// Return the total number of constraints in the system.
+    pub fn number_of_constraints(&self) -> usize {
+        let mut constraint_count: usize = 0;
+        for constraint_vec in self.constraints.values() {
+            constraint_count += constraint_vec.len();
+        }
+        constraint_count
+    }
 }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -27,6 +27,7 @@ impl ConcreteExpression {
         Self::Identifier(Box::new(ConcreteIdentifierExpression {
             expression_type: ConcreteType::default_for_test(),
             name: name.to_string(),
+            is_disregarded: false,
         }))
     }
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -35,6 +35,7 @@ pub struct TypedFunctionExpression<T> {
 pub struct TypedIdentifierExpression<T> {
     pub expression_type: T,
     pub name: String,
+    pub is_disregarded: bool,
 }
 
 // TODO(nick): add this to JS backend


### PR DESCRIPTION
Does not implement or test translation of `FunctionApplication`, `MethodLookup`, or `FieldLookup`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unary_tests","parentHead":"2db94f68809bac670414cdaf36f71d69631849a2","parentPull":58,"trunk":"main"}
```
-->
