### PR TITLE
Move expression context into its own file

### DIFF
--- a/rust/parser/src/expression_context.rs
+++ b/rust/parser/src/expression_context.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExpressionContext {
+    pub indentation: usize,
+    pub allow_newlines_in_expressions: bool,
+}
+
+impl ExpressionContext {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            indentation: 0,
+            allow_newlines_in_expressions: false,
+        }
+    }
+
+    #[must_use]
+    /// Creates a new `ExpressionContext` whose expected level of indentation is one greater
+    /// than the object on which this method is invoked.
+    pub const fn increment_indentation(&self) -> Self {
+        Self {
+            indentation: self.indentation + 1,
+            allow_newlines_in_expressions: self.allow_newlines_in_expressions,
+        }
+    }
+
+    #[must_use]
+    /// Creates a copy of `self` that allows newlines in expressions.
+    pub const fn allow_newlines_in_expressions(&self) -> Self {
+        Self {
+            indentation: self.indentation,
+            allow_newlines_in_expressions: true,
+        }
+    }
+
+    #[must_use]
+    /// Creates a copy of `self` that disallows newlines in expressions.
+    pub const fn disallow_newlines_in_expressions(&self) -> Self {
+        Self {
+            indentation: self.indentation,
+            allow_newlines_in_expressions: false,
+        }
+    }
+}

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -3,6 +3,7 @@ mod binary_operator_expression;
 mod binary_operator_or_if;
 mod block;
 mod document;
+mod expression_context;
 mod function;
 mod function_argument;
 mod function_type;
@@ -32,47 +33,4 @@ mod unary_operator;
 mod variable_declaration;
 
 use binary_operator_or_if::binary_operator_or_if as expression;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ExpressionContext {
-    pub indentation: usize,
-    pub allow_newlines_in_expressions: bool,
-}
-
-impl ExpressionContext {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            indentation: 0,
-            allow_newlines_in_expressions: false,
-        }
-    }
-
-    #[must_use]
-    /// Creates a new `ExpressionContext` whose expected level of indentation is one greater
-    /// than the object on which this method is invoked.
-    pub const fn increment_indentation(&self) -> Self {
-        Self {
-            indentation: self.indentation + 1,
-            allow_newlines_in_expressions: self.allow_newlines_in_expressions,
-        }
-    }
-
-    #[must_use]
-    /// Creates a copy of `self` that allows newlines in expressions.
-    pub const fn allow_newlines_in_expressions(&self) -> Self {
-        Self {
-            indentation: self.indentation,
-            allow_newlines_in_expressions: true,
-        }
-    }
-
-    #[must_use]
-    /// Creates a copy of `self` that disallows newlines in expressions.
-    pub const fn disallow_newlines_in_expressions(&self) -> Self {
-        Self {
-            indentation: self.indentation,
-            allow_newlines_in_expressions: false,
-        }
-    }
-}
+use expression_context::ExpressionContext;


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"list-test-block","parentHead":"356375b3178cb30d56e5dbe32580d0b21954dbea","parentPull":61,"trunk":"main"}
```
-->
