### PR TITLE
Parse Buri file

### DIFF
--- a/rust/parser/src/file.rs
+++ b/rust/parser/src/file.rs
@@ -1,0 +1,12 @@
+use crate::document::document;
+use ast::{DocumentNode, ParserInput};
+use nom::{combinator::eof, sequence::terminated};
+
+pub fn parse_buri_file(source: &str) -> Result<DocumentNode, String> {
+    let input = ParserInput::new(source);
+    let result = terminated(document(), eof)(input);
+    match result {
+        Ok((_, document)) => Ok(document),
+        Err(error) => Err(error.to_string()),
+    }
+}

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -4,6 +4,7 @@ mod binary_operator_or_if;
 mod block;
 mod document;
 mod expression_context;
+mod file;
 mod function;
 mod function_argument;
 mod function_type;
@@ -34,3 +35,4 @@ mod variable_declaration;
 
 use binary_operator_or_if::binary_operator_or_if as expression;
 use expression_context::ExpressionContext;
+pub use file::parse_buri_file;


### PR DESCRIPTION
In contrast to the document parser, the goal of this function is to translate the parser's input and return values into the more desirable API.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"expression-context","parentHead":"443275801d140266ee1c8e13a5719735ba4485cc","parentPull":62,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"expression-context","parentHead":"443275801d140266ee1c8e13a5719735ba4485cc","parentPull":62,"trunk":"main"}
```
-->
