### PR TITLE
Remove unused imports

### DIFF
--- a/rust/parser/src/binary_operator_expression.rs
+++ b/rust/parser/src/binary_operator_expression.rs
@@ -255,8 +255,6 @@ pub fn binary_operator_expression<'a>(
 mod test {
     use super::*;
 
-    use ast::IdentifierValue;
-
     #[test]
     fn empty_input_is_not_binary_operator_expression() {
         let input = ParserInput::new("");

--- a/rust/parser/src/record_type.rs
+++ b/rust/parser/src/record_type.rs
@@ -72,8 +72,7 @@ pub fn record_type(input: ParserInput) -> IResult<RecordTypeNode> {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    use ast::{Expression, TypeExpression};
+    use ast::TypeExpression;
 
     #[test]
     fn empty_record_produces_empty_output() {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"export-decoration","parentHead":"0c37209021a00b2e3d2e96747d13ceff8d0c9184","parentPull":66,"trunk":"main"}
```
-->
