### PR TITLE
Parse tag groups

### DIFF
--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -216,7 +216,6 @@ pub enum TypeExpression<'a> {
     Identifier(TypeIdentifierNode<'a>),
     List(Box<ListTypeNode<'a>>),
     Record(RecordTypeNode<'a>),
-    Tag(TagTypeNode<'a>),
     TagGroup(TagGroupTypeNode<'a>),
 }
 

--- a/rust/parser/src/function_type.rs
+++ b/rust/parser/src/function_type.rs
@@ -105,7 +105,7 @@ mod test {
         } = function;
         assert_eq!(arguments.len(), 2);
         assert!(matches!(arguments[0], TypeExpression::List(_)));
-        assert!(matches!(arguments[1], TypeExpression::Tag(_)));
+        assert!(matches!(arguments[1], TypeExpression::TagGroup(_)));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod test {
         } = function;
         assert_eq!(arguments.len(), 2);
         assert!(matches!(arguments[0], TypeExpression::List(_)));
-        assert!(matches!(arguments[1], TypeExpression::Tag(_)));
+        assert!(matches!(arguments[1], TypeExpression::TagGroup(_)));
     }
 
     #[test]

--- a/rust/parser/src/tag_group_type.rs
+++ b/rust/parser/src/tag_group_type.rs
@@ -92,4 +92,11 @@ mod test {
         let (_, parsed) = tag_group_type(input).unwrap();
         assert_eq!(parsed.value.len(), 2);
     }
+
+    #[test]
+    fn commas_are_not_parsed() {
+        let input = ParserInput::new("#hello,");
+        let (remainder, _) = tag_group_type(input).unwrap();
+        assert_eq!(remainder, ",");
+    }
 }

--- a/rust/parser/src/type_expression.rs
+++ b/rust/parser/src/type_expression.rs
@@ -1,6 +1,7 @@
+use crate::tag_group_type::tag_group_type;
 use crate::{
     function_type::function_type, list_type::list_type, record_type::record_type,
-    tag_type::tag_type, type_identifier::type_identifier,
+    type_identifier::type_identifier,
 };
 use ast::TypeExpression;
 use ast::{IResult, ParserInput};
@@ -10,7 +11,7 @@ pub fn type_expression(input: ParserInput) -> IResult<TypeExpression> {
     alt((
         map(type_identifier, TypeExpression::Identifier),
         map(list_type, |list| TypeExpression::List(Box::new(list))),
-        map(tag_type, TypeExpression::Tag),
+        map(tag_group_type, TypeExpression::TagGroup),
         map(record_type, TypeExpression::Record),
         map(function_type, TypeExpression::Function),
     ))(input)
@@ -42,10 +43,17 @@ mod test {
     }
 
     #[test]
-    fn a_tag_type_is_a_type_expression() {
+    fn a_single_tag_type_is_a_type_expression() {
         let input = ParserInput::new("#hello");
         let (_, expression) = type_expression(input.clone()).unwrap();
-        assert!(matches!(expression, TypeExpression::Tag(_)));
+        assert!(matches!(expression, TypeExpression::TagGroup(_)));
+    }
+
+    #[test]
+    fn a_tag_group_type_is_a_type_expression() {
+        let input = ParserInput::new("#hello | #world");
+        let (_, expression) = type_expression(input.clone()).unwrap();
+        assert!(matches!(expression, TypeExpression::TagGroup(_)));
     }
 
     #[test]


### PR DESCRIPTION
I realized we never parsed tag groups fully.

For type expressions, I opted to only have tag groups instead of just tags. It just seems simpler that way. I can explain in more detail if this feels controversial.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unused-imports","parentHead":"20180816dd0ce094ac86be74c85d413fdd4fb6be","parentPull":67,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unused-imports","parentHead":"20180816dd0ce094ac86be74c85d413fdd4fb6be","parentPull":67,"trunk":"main"}
```
-->
