### PR TITLE
Parse record assignment (B-212)

### DIFF
--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -112,6 +112,12 @@ pub struct RecordValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordAssignmentValue<'a> {
+    pub identifier: IdentifierNode<'a>,
+    pub new_values: Vec<RecordValue<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordTypeValue<'a> {
     /// The name of the record.
     pub identifier: IdentifierNode<'a>,
@@ -182,6 +188,7 @@ pub type ImportNode<'a> = ParsedNode<'a, ImportValue<'a>>;
 pub type IntegerNode<'a> = ParsedNode<'a, u64>;
 pub type ListNode<'a> = ParsedNode<'a, Vec<Expression<'a>>>;
 pub type ListTypeNode<'a> = ParsedNode<'a, TypeExpression<'a>>;
+pub type RecordAssignmentNode<'a> = ParsedNode<'a, RecordAssignmentValue<'a>>;
 pub type RecordNode<'a> = ParsedNode<'a, Vec<RecordValue<'a>>>;
 pub type RecordTypeNode<'a> = ParsedNode<'a, Vec<RecordTypeValue<'a>>>;
 pub type StringLiteralNode<'a> = ParsedNode<'a, String>;
@@ -205,6 +212,7 @@ pub enum Expression<'a> {
     Integer(IntegerNode<'a>),
     List(ListNode<'a>),
     Record(RecordNode<'a>),
+    RecordAssignment(RecordAssignmentNode<'a>),
     StringLiteral(StringLiteralNode<'a>),
     Tag(TagNode<'a>),
     UnaryOperator(UnaryOperatorNode<'a>),

--- a/rust/parser/src/basic_expression.rs
+++ b/rust/parser/src/basic_expression.rs
@@ -1,7 +1,8 @@
 use crate::{
     function::function, identifier::identifier, integer::integer, list::list,
-    parentheses::parentheses, record::record, string_literal::string_literal, tag::tag,
-    unary_operator::unary_operator_expression, ExpressionContext,
+    parentheses::parentheses, record::record, record_assignment::record_assignment,
+    string_literal::string_literal, tag::tag, unary_operator::unary_operator_expression,
+    ExpressionContext,
 };
 use ast::{Expression, IResult, ParserInput};
 use nom::{branch::alt, combinator::map};
@@ -22,6 +23,10 @@ pub fn basic_expression<'a>(
         map(record, Expression::Record),
         map(tag, Expression::Tag),
         map(move |input| function(context, input), Expression::Function),
+        map(
+            move |input| record_assignment(context, input),
+            Expression::RecordAssignment,
+        ),
     ))
 }
 
@@ -90,5 +95,14 @@ mod test {
             basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
         let (_, consumed) = result.unwrap();
         assert!(matches!(consumed, Expression::Function(_)));
+    }
+
+    #[test]
+    fn expression_can_be_a_record_assignment() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let result =
+            basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
+        let (_, consumed) = result.unwrap();
+        assert!(matches!(consumed, Expression::RecordAssignment(_)));
     }
 }

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -21,6 +21,7 @@ mod list_type;
 mod newline;
 mod parentheses;
 mod record;
+mod record_assignment;
 mod record_type;
 mod string_literal;
 mod tag;

--- a/rust/parser/src/record_assignment.rs
+++ b/rust/parser/src/record_assignment.rs
@@ -1,0 +1,141 @@
+use crate::{
+    expression_context::ExpressionContext,
+    identifier::identifier,
+    intra_expression_whitespace::intra_expression_whitespace,
+    record::{record_closing_delimiter, record_opening_delimiter, record_values},
+};
+use ast::{IResult, ParserInput, RecordAssignmentNode, RecordAssignmentValue};
+use nom::{
+    character::complete::char,
+    combinator::{consumed, map, opt},
+    sequence::{delimited, separated_pair, tuple},
+};
+
+pub fn record_assignment(
+    context: ExpressionContext,
+    input: ParserInput,
+) -> IResult<RecordAssignmentNode> {
+    map(
+        consumed(delimited(
+            record_opening_delimiter,
+            separated_pair(
+                identifier,
+                tuple((
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                    char('|'),
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                )),
+                record_values,
+            ),
+            record_closing_delimiter,
+        )),
+        |(consumed, (identifier, new_values))| RecordAssignmentNode {
+            source: consumed,
+            value: RecordAssignmentValue {
+                identifier,
+                new_values,
+            },
+        },
+    )(input)
+}
+
+#[cfg(test)]
+mod test {
+    use ast::Expression;
+
+    use super::*;
+
+    #[test]
+    fn assignment_can_parse() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parses_identifier_correctly() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.identifier.value.name, "hello");
+    }
+
+    #[test]
+    fn identifier_cannot_be_an_expression() {
+        let input = ParserInput::new("{hello()|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn identifier_cannot_be_type() {
+        let input = ParserInput::new("{Hello|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parses_one_value() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 1);
+    }
+
+    #[test]
+    fn parses_two_values_separated_by_a_comma() {
+        let input = ParserInput::new("{hello|name:\"world\",age:24}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 2);
+    }
+
+    #[test]
+    fn trailing_commas_do_not_parse_into_an_additional_item() {
+        let input = ParserInput::new("{hello|name:\"world\",}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 1);
+    }
+
+    #[test]
+    fn parses_value_identifier() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(
+            parsed
+                .value
+                .new_values
+                .get(0)
+                .unwrap()
+                .identifier
+                .value
+                .name,
+            "name"
+        );
+    }
+
+    #[test]
+    fn parses_value_expression() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert!(matches!(
+            parsed.value.new_values.get(0).unwrap().value,
+            Expression::StringLiteral(_)
+        ));
+    }
+
+    #[test]
+    fn can_have_spaces_anywhere() {
+        let input = ParserInput::new("{  hello  |  name  :  \"world\"  ,  }");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn can_have_newlines_anywhere() {
+        let input = ParserInput::new("{\n\nhello\n\n|\n\nname\n\n:\n\n\"world\"\n\n,\n\n}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
This looks like a larger change than it is. Much of the PR is extracting out some of the record parsing internals into their own functions so I can reuse them here. That way we can guarantee that they'll both have the same behavior.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-declaration","parentHead":"87eedca5c4c5ecd6c17ff0f084cb37bfb9cf7ece","parentPull":71,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-declaration","parentHead":"87eedca5c4c5ecd6c17ff0f084cb37bfb9cf7ece","parentPull":71,"trunk":"main"}
```
-->
