### PR TITLE
Remove unused import

### DIFF
--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -17,7 +17,7 @@ pub fn print_list(list: &ConcreteListExpression) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
+    use typed_ast::{ConcreteExpression, ConcreteType};
 
     #[test]
     fn can_print_list_of_integers() {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"print-record-assignment","parentHead":"9b6d7decf015af028969b48ccee43b8d057e95b5","parentPull":73,"trunk":"main"}
```
-->
