### PR TITLE
Remove tag output optimization that causes bugs in incremental builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ name = "js_backend"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "parser",
  "typed_ast",
 ]
 

--- a/packages/std/prelude/record.js
+++ b/packages/std/prelude/record.js
@@ -4,22 +4,36 @@ Object.assign(Object.prototype, {
     },
 
     /** Allows us to set a key on an object without mutating the original object.
-    /*
-    /* In Buri, you can write the following code:
-    /*
-    /* ```buri
-    /* person = { name: "Sam", age: 30 }
-    /* theodore = person:set(#name, "Theodore")
-    /* ```
-    /*
-    /* This is compiled to the following JS code:
-    /*
-    /* ```js
-    /* let person = { name: "Sam", age: 30 }
-    /* let theodore = person.$set("name", "Theodore")
-    /* ```
+     *
+     * In Buri, you can write the following code:
+     *
+     * ```buri
+     * person = { name: "Sam", age: 30 }
+     * theodore = { person | name: "Theodore" }
+     * ```
+     *
+     * This is compiled to the following JS code:
+     *
+     * ```js
+     * let person = { name: "Sam", age: 30 }
+     * let theodore = person.$set({ name: "Theodore" })
+     * ```
+     *
+     * It's worth noting that in Buri you can assign multiple keys at once:
+     *
+     * ```buri
+     * person = { name: "Sam", age: 30 }
+     * theodore = { person | name: "Theodore", age: 31 }
+     * ```
+     *
+     * This is compiled to the following JS code:
+     *
+     * ```js
+     * let person = { name: "Sam", age: 30 }
+     * let theodore = person.$set({ name: "Theodore", age: 31 })
+     * ```
      */
-    $set(key, value) {
-        return new this.constructor({ ...this.valueOf(), [key]: value })
+    $set(newValues) {
+        return new this.constructor({ ...this.valueOf(), ...newValues })
     },
 })

--- a/packages/std/prelude/record.test.js
+++ b/packages/std/prelude/record.test.js
@@ -23,12 +23,12 @@ it("trait methods added to records should be available after cloning", () => {
 
 it("can set keys by their name", () => {
     const record = { a: 1, b: 2 }
-    const newRecord = record.$set("a", 3)
+    const newRecord = record.$set({ a: 3 })
     expect(newRecord.a).toBe(3)
 })
 
 it("setting a key produces a new object", () => {
     const record = { a: 1, b: 2 }
-    const newRecord = record.$set("a", 3)
+    const newRecord = record.$set({ a: 3 })
     expect(newRecord).not.toBe(record)
 })

--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -112,6 +112,12 @@ pub struct RecordValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordAssignmentValue<'a> {
+    pub identifier: IdentifierNode<'a>,
+    pub new_values: Vec<RecordValue<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordTypeValue<'a> {
     /// The name of the record.
     pub identifier: IdentifierNode<'a>,
@@ -182,6 +188,7 @@ pub type ImportNode<'a> = ParsedNode<'a, ImportValue<'a>>;
 pub type IntegerNode<'a> = ParsedNode<'a, u64>;
 pub type ListNode<'a> = ParsedNode<'a, Vec<Expression<'a>>>;
 pub type ListTypeNode<'a> = ParsedNode<'a, TypeExpression<'a>>;
+pub type RecordAssignmentNode<'a> = ParsedNode<'a, RecordAssignmentValue<'a>>;
 pub type RecordNode<'a> = ParsedNode<'a, Vec<RecordValue<'a>>>;
 pub type RecordTypeNode<'a> = ParsedNode<'a, Vec<RecordTypeValue<'a>>>;
 pub type StringLiteralNode<'a> = ParsedNode<'a, String>;
@@ -205,6 +212,7 @@ pub enum Expression<'a> {
     Integer(IntegerNode<'a>),
     List(ListNode<'a>),
     Record(RecordNode<'a>),
+    RecordAssignment(RecordAssignmentNode<'a>),
     StringLiteral(StringLiteralNode<'a>),
     Tag(TagNode<'a>),
     UnaryOperator(UnaryOperatorNode<'a>),

--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -51,10 +51,16 @@ pub struct BinaryOperatorValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopLevelDeclaration<T> {
+    pub declaration: T,
+    pub is_exported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentValue<'a> {
     pub imports: Vec<ImportNode<'a>>,
-    pub type_declarations: Vec<TypeDeclarationNode<'a>>,
-    pub variable_declarations: Vec<VariableDeclarationNode<'a>>,
+    pub type_declarations: Vec<TopLevelDeclaration<TypeDeclarationNode<'a>>>,
+    pub variable_declarations: Vec<TopLevelDeclaration<VariableDeclarationNode<'a>>>,
     pub expressions: Vec<Expression<'a>>,
 }
 

--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -219,9 +219,3 @@ pub enum ImportedIdentifier<'a> {
     Identifier(IdentifierNode<'a>),
     TypeIdentifier(TypeIdentifierNode<'a>),
 }
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BuriAstNodeValue<'a> {
-    Expression(Expression<'a>),
-    Identifier(IdentifierNode<'a>),
-}

--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -216,7 +216,6 @@ pub enum TypeExpression<'a> {
     Identifier(TypeIdentifierNode<'a>),
     List(Box<ListTypeNode<'a>>),
     Record(RecordTypeNode<'a>),
-    Tag(TagTypeNode<'a>),
     TagGroup(TagGroupTypeNode<'a>),
 }
 

--- a/rust/js_backend/Cargo.toml
+++ b/rust/js_backend/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 ast = { path = "../ast" }
 typed_ast = { path = "../typed_ast" }
+
+[dev-dependencies]
+parser = { path = "../parser" }

--- a/rust/js_backend/src/expression/declaration.rs
+++ b/rust/js_backend/src/expression/declaration.rs
@@ -1,0 +1,53 @@
+use crate::{expression::print_expression, identifier::print_identifier};
+use typed_ast::ConcreteDeclarationExpression;
+
+pub fn print_declaration(declaration: &ConcreteDeclarationExpression) -> String {
+    let export = if declaration.is_exported {
+        "export "
+    } else {
+        ""
+    };
+    let identifier = print_identifier(&declaration.identifier);
+    let value = print_expression(&declaration.value);
+    format!("{export}const {identifier}={value}")
+}
+
+#[cfg(test)]
+mod test {
+    use typed_ast::{ConcreteExpression, ConcreteType};
+
+    use super::*;
+
+    #[test]
+    fn declare_an_integer() {
+        let declaration = ConcreteDeclarationExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            identifier: ConcreteExpression::raw_identifier_for_test("foo"),
+            value: ConcreteExpression::integer_for_test(42),
+            is_exported: false,
+        };
+        assert_eq!(print_declaration(&declaration), "const foo=42");
+    }
+
+    #[test]
+    fn declare_a_string() {
+        let declaration = ConcreteDeclarationExpression {
+            expression_type: ConcreteType::default_string_for_test(),
+            identifier: ConcreteExpression::raw_identifier_for_test("hello"),
+            value: ConcreteExpression::string_for_test("world"),
+            is_exported: false,
+        };
+        assert_eq!(print_declaration(&declaration), "const hello=\"world\"");
+    }
+
+    #[test]
+    fn can_export_declarations() {
+        let declaration = ConcreteDeclarationExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            identifier: ConcreteExpression::raw_identifier_for_test("foo"),
+            value: ConcreteExpression::integer_for_test(42),
+            is_exported: true,
+        };
+        assert_eq!(print_declaration(&declaration), "export const foo=42");
+    }
+}

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -17,7 +17,7 @@ pub fn print_list(list: &ConcreteListExpression) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
+    use typed_ast::{ConcreteExpression, ConcreteType};
 
     #[test]
     fn can_print_list_of_integers() {

--- a/rust/js_backend/src/expression/list.rs
+++ b/rust/js_backend/src/expression/list.rs
@@ -16,9 +16,8 @@ pub fn print_list(list: &ConcreteListExpression) -> String {
 
 #[cfg(test)]
 mod test {
-    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
-
     use super::*;
+    use typed_ast::{ConcreteExpression, ConcreteStringLiteralExpression, ConcreteType};
 
     #[test]
     fn can_print_list_of_integers() {
@@ -51,5 +50,20 @@ mod test {
             ],
         };
         assert_eq!(print_list(&list), "[\"foo\",\"bar\"]");
+    }
+
+    #[test]
+    fn can_print_list_with_blocks() {
+        let list = ConcreteListExpression {
+            expression_type: ConcreteType::default_list_for_test(),
+            contents: vec![
+                ConcreteExpression::integer_for_test(42),
+                ConcreteExpression::block_for_test(vec![
+                    ConcreteExpression::integer_for_test(43),
+                    ConcreteExpression::integer_for_test(44),
+                ]),
+            ],
+        };
+        assert_eq!(print_list(&list), "[42,(()=>{43;return 44;})()]");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -133,10 +133,10 @@ mod test {
     fn print_tag() {
         let tag = ConcreteExpression::Tag(Box::new(ConcreteTagExpression {
             name: "foo".to_string(),
-            expression_type: ConcreteType::default_tag_union_for_test(false),
+            expression_type: ConcreteType::default_tag_union_for_test(),
             contents: vec![],
         }));
-        assert_eq!(print_expression(&tag), "\"foo\"");
+        assert_eq!(print_expression(&tag), "[\"foo\"]");
     }
 
     #[test]

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -6,6 +6,7 @@ mod function_declaration;
 mod if_expression;
 mod list;
 mod record;
+mod record_assignment;
 mod tag;
 mod unary_operator;
 
@@ -21,6 +22,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Integer(integer) => print_integer_literal(integer),
         ConcreteExpression::StringLiteral(string) => print_string_literal(string),
         ConcreteExpression::Record(record) => record::print_record(record),
+        ConcreteExpression::RecordAssignment(assignment) => {
+            record_assignment::print_record_assignment(assignment)
+        }
         ConcreteExpression::List(list) => list::print_list(list),
         ConcreteExpression::BinaryOperator(operator) => {
             binary_operator::print_binary_operator(operator)
@@ -41,15 +45,15 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use super::*;
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
+    use std::collections::HashMap;
     use typed_ast::{
         ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteBooleanExpression,
         ConcreteDeclarationExpression, ConcreteFunctionExpression, ConcreteIfExpression,
-        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
-        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression, PrimitiveType,
+        ConcreteListExpression, ConcreteRecordAssignmentExpression, ConcreteRecordExpression,
+        ConcreteStringLiteralExpression, ConcreteTagExpression, ConcreteType,
+        ConcreteUnaryOperatorExpression, PrimitiveType,
     };
 
     #[test]
@@ -184,5 +188,27 @@ mod test {
                 is_exported: false,
             }));
         assert_eq!(print_expression(&declaration), "const foo=42");
+    }
+
+    #[test]
+    fn print_record_assignment() {
+        let record = ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([(
+                "meaningOfLife".to_string(),
+                ConcreteExpression::integer_for_test(42),
+            )]),
+        };
+        let identifier = ConcreteExpression::raw_identifier_for_test("hello");
+        let assignment =
+            ConcreteExpression::RecordAssignment(Box::new(ConcreteRecordAssignmentExpression {
+                expression_type: ConcreteType::default_record_for_test(),
+                contents: record,
+                identifier,
+            }));
+        assert_eq!(
+            print_expression(&assignment),
+            "hello.$set({meaningOfLife: 42})"
+        );
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -1,6 +1,7 @@
 mod binary_operator;
 mod block;
 mod boolean;
+mod declaration;
 mod function_declaration;
 mod if_expression;
 mod list;
@@ -34,6 +35,7 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
             function_declaration::print_function_declaration(function)
         }
         ConcreteExpression::Boolean(boolean) => boolean::print_boolean(boolean),
+        ConcreteExpression::Declaration(declaration) => declaration::print_declaration(declaration),
     }
 }
 
@@ -45,9 +47,9 @@ mod test {
     use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
     use typed_ast::{
         ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteBooleanExpression,
-        ConcreteFunctionExpression, ConcreteIfExpression, ConcreteListExpression,
-        ConcreteRecordExpression, ConcreteStringLiteralExpression, ConcreteTagExpression,
-        ConcreteType, ConcreteUnaryOperatorExpression, PrimitiveType,
+        ConcreteDeclarationExpression, ConcreteFunctionExpression, ConcreteIfExpression,
+        ConcreteListExpression, ConcreteRecordExpression, ConcreteStringLiteralExpression,
+        ConcreteTagExpression, ConcreteType, ConcreteUnaryOperatorExpression, PrimitiveType,
     };
 
     #[test]
@@ -170,5 +172,17 @@ mod test {
             value: true,
         }));
         assert_eq!(print_expression(&boolean), "true");
+    }
+
+    #[test]
+    fn print_declaration() {
+        let declaration =
+            ConcreteExpression::Declaration(Box::new(ConcreteDeclarationExpression {
+                expression_type: ConcreteType::default_integer_for_test(),
+                identifier: ConcreteExpression::raw_identifier_for_test("foo"),
+                value: ConcreteExpression::integer_for_test(42),
+                is_exported: false,
+            }));
+        assert_eq!(print_expression(&declaration), "const foo=42");
     }
 }

--- a/rust/js_backend/src/expression/record_assignment.rs
+++ b/rust/js_backend/src/expression/record_assignment.rs
@@ -1,0 +1,62 @@
+use crate::expression::record::print_record;
+use crate::identifier::print_identifier;
+use typed_ast::ConcreteRecordAssignmentExpression;
+
+pub fn print_record_assignment(assignment: &ConcreteRecordAssignmentExpression) -> String {
+    let identifier = print_identifier(&assignment.identifier);
+    let new_values = print_record(&assignment.contents);
+    format!("{identifier}.$set({new_values})")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+    use typed_ast::{ConcreteExpression, ConcreteRecordExpression, ConcreteType};
+
+    #[test]
+    fn assigns_a_single_value() {
+        let record = ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([(
+                "meaningOfLife".to_string(),
+                ConcreteExpression::integer_for_test(42),
+            )]),
+        };
+        let identifier = ConcreteExpression::raw_identifier_for_test("hello");
+        let assignment = ConcreteRecordAssignmentExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: record,
+            identifier,
+        };
+        let result = print_record_assignment(&assignment);
+        assert_eq!(result, "hello.$set({meaningOfLife: 42})");
+    }
+
+    #[test]
+    fn assigns_multiple_values() {
+        let record = ConcreteRecordExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: HashMap::from([
+                (
+                    "meaningOfLife".to_string(),
+                    ConcreteExpression::integer_for_test(42),
+                ),
+                ("foo".to_string(), ConcreteExpression::integer_for_test(0)),
+            ]),
+        };
+        let identifier = ConcreteExpression::raw_identifier_for_test("hello");
+        let assignment = ConcreteRecordAssignmentExpression {
+            expression_type: ConcreteType::default_record_for_test(),
+            contents: record,
+            identifier,
+        };
+        let result = print_record_assignment(&assignment);
+        // Because of the HashMap, the order of the keys is not guaranteed.
+        // However, the order doesn't matter so we can accept either one.
+        assert!(
+            result == "hello.$set({meaningOfLife: 42, foo: 0})"
+                || result == "hello.$set({foo: 0, meaningOfLife: 42})"
+        );
+    }
+}

--- a/rust/js_backend/src/expression/tag.rs
+++ b/rust/js_backend/src/expression/tag.rs
@@ -1,54 +1,34 @@
-use typed_ast::{ConcreteTagExpression, ConcreteType};
+use typed_ast::ConcreteTagExpression;
 
 pub fn print_tag(tag: &ConcreteTagExpression) -> String {
-    let some_tags_have_content;
-    if let ConcreteType::TagUnion(tag_union_type) = &tag.expression_type {
-        some_tags_have_content = tag_union_type.some_tags_have_content;
-    } else {
-        panic!("Expected tag to have tag union type");
+    let mut output = String::new();
+    output.push_str("[\"");
+    output.push_str(&tag.name);
+    output.push('"');
+    if !tag.contents.is_empty() {
+        let contents = tag
+            .contents
+            .iter()
+            .map(super::print_expression)
+            .collect::<Vec<_>>()
+            .join(", ");
+        output.push(',');
+        output.push_str(&contents);
     }
-    if some_tags_have_content {
-        let mut output = String::new();
-        output.push_str("[\"");
-        output.push_str(&tag.name);
-        output.push('"');
-        if !tag.contents.is_empty() {
-            let contents = tag
-                .contents
-                .iter()
-                .map(super::print_expression)
-                .collect::<Vec<_>>()
-                .join(", ");
-            output.push(',');
-            output.push_str(&contents);
-        }
-        output.push(']');
-        output
-    } else {
-        format!("\"{}\"", tag.name)
-    }
+    output.push(']');
+    output
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use typed_ast::ConcreteExpression;
-
-    #[test]
-    fn tags_in_tag_unions_without_contents_are_strings() {
-        let tag = ConcreteTagExpression {
-            name: "foo".to_string(),
-            expression_type: ConcreteType::default_tag_union_for_test(false),
-            contents: vec![],
-        };
-        assert_eq!(print_tag(&tag), "\"foo\"");
-    }
+    use typed_ast::{ConcreteExpression, ConcreteType};
 
     #[test]
     fn tags_without_contents_are_arrays_when_some_tags_have_content() {
         let tag = ConcreteTagExpression {
             name: "foo".to_string(),
-            expression_type: ConcreteType::default_tag_union_for_test(true),
+            expression_type: ConcreteType::default_tag_union_for_test(),
             contents: vec![],
         };
         assert_eq!(print_tag(&tag), "[\"foo\"]");
@@ -58,7 +38,7 @@ mod test {
     fn tags_with_contents_are_arrays_when_some_tags_have_content() {
         let tag = ConcreteTagExpression {
             name: "foo".to_string(),
-            expression_type: ConcreteType::default_tag_union_for_test(true),
+            expression_type: ConcreteType::default_tag_union_for_test(),
             contents: vec![ConcreteExpression::integer_for_test(42)],
         };
         assert_eq!(print_tag(&tag), "[\"foo\",42]");

--- a/rust/js_backend/src/imports.rs
+++ b/rust/js_backend/src/imports.rs
@@ -1,0 +1,105 @@
+use ast::{IdentifierNode, ImportNode, ImportedIdentifier};
+
+fn filter_identifiers<'a>(
+    imported_identifiers: &[ImportedIdentifier<'a>],
+) -> Vec<IdentifierNode<'a>> {
+    imported_identifiers
+        .iter()
+        .filter_map(|imported_identifier| match imported_identifier {
+            ImportedIdentifier::Identifier(identifier) => Some(identifier.clone()),
+            ImportedIdentifier::TypeIdentifier(_) => None,
+        })
+        .collect()
+}
+
+fn format_path(path: &str) -> String {
+    let mut result = String::new();
+    result.push('"');
+    result.push_str(path.replace(".buri", ".mjs").as_str());
+    result.push('"');
+    result
+}
+
+fn print_import(import: &ImportNode) -> String {
+    let identifiers = filter_identifiers(&import.value.identifiers);
+    if identifiers.is_empty() {
+        return String::new();
+    }
+    let mut result = String::new();
+    result.push_str("import {");
+    for (index, identifier) in identifiers.iter().enumerate() {
+        result.push_str(&identifier.value.name);
+        if index < identifiers.len() - 1 {
+            result.push(',');
+        }
+    }
+    result.push_str("} from ");
+    result.push_str(format_path(import.value.path).as_str());
+    result
+}
+
+pub fn print_imports(imports: &[ImportNode]) -> String {
+    let mut result = String::new();
+    for import in imports {
+        let import_statement = print_import(import);
+        if import_statement.is_empty() {
+            continue;
+        }
+        result.push_str(&import_statement);
+        result.push('\n');
+    }
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use parser::parse_buri_file;
+
+    #[test]
+    fn prints_import_with_single_identifier() {
+        let file = "import foo from \"foo.buri\"";
+        let document = parse_buri_file(file).unwrap();
+        assert_eq!(
+            print_imports(&document.value.imports),
+            "import {foo} from \"foo.mjs\"\n"
+        );
+    }
+
+    #[test]
+    fn prints_import_with_multiple_identifiers() {
+        let file = "import foo, bar from \"foo.buri\"";
+        let document = parse_buri_file(file).unwrap();
+        assert_eq!(
+            print_imports(&document.value.imports),
+            "import {foo,bar} from \"foo.mjs\"\n"
+        );
+    }
+
+    #[test]
+    fn ignore_type_identifiers() {
+        let file = "import foo, bar, Baz from \"foo.buri\"";
+        let document = parse_buri_file(file).unwrap();
+        assert_eq!(
+            print_imports(&document.value.imports),
+            "import {foo,bar} from \"foo.mjs\"\n"
+        );
+    }
+
+    #[test]
+    fn prints_import_with_multiple_imports() {
+        let file = "import foo from \"foo.buri\"\nimport bar from \"bar.buri\"";
+        let document = parse_buri_file(file).unwrap();
+        assert_eq!(
+            print_imports(&document.value.imports),
+            "import {foo} from \"foo.mjs\"\nimport {bar} from \"bar.mjs\"\n"
+        );
+    }
+
+    #[test]
+    fn if_only_types_are_imported_delete_the_import_statement() {
+        let file = "import Baz from \"foo.buri\"";
+        let document = parse_buri_file(file).unwrap();
+        assert_eq!(print_imports(&document.value.imports), "");
+    }
+}

--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -1,3 +1,4 @@
 mod expression;
 mod identifier;
+mod imports;
 mod literals;

--- a/rust/parser/src/basic_expression.rs
+++ b/rust/parser/src/basic_expression.rs
@@ -1,7 +1,7 @@
 use crate::{
-    identifier::identifier, integer::integer, list::list, parentheses::parentheses, record::record,
-    string_literal::string_literal, tag::tag, unary_operator::unary_operator_expression,
-    ExpressionContext,
+    function::function, identifier::identifier, integer::integer, list::list,
+    parentheses::parentheses, record::record, string_literal::string_literal, tag::tag,
+    unary_operator::unary_operator_expression, ExpressionContext,
 };
 use ast::{Expression, IResult, ParserInput};
 use nom::{branch::alt, combinator::map};
@@ -21,6 +21,7 @@ pub fn basic_expression<'a>(
         map(list, Expression::List),
         map(record, Expression::Record),
         map(tag, Expression::Tag),
+        map(move |input| function(context, input), Expression::Function),
     ))
 }
 
@@ -80,5 +81,14 @@ mod test {
             basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
         let (_, consumed) = result.unwrap();
         assert!(matches!(consumed, Expression::Tag(_)));
+    }
+
+    #[test]
+    fn expression_can_be_a_function() {
+        let input = ParserInput::new("() => 42");
+        let result =
+            basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
+        let (_, consumed) = result.unwrap();
+        assert!(matches!(consumed, Expression::Function(_)));
     }
 }

--- a/rust/parser/src/basic_expression.rs
+++ b/rust/parser/src/basic_expression.rs
@@ -1,7 +1,8 @@
 use crate::{
     function::function, identifier::identifier, integer::integer, list::list,
-    parentheses::parentheses, record::record, string_literal::string_literal, tag::tag,
-    unary_operator::unary_operator_expression, ExpressionContext,
+    parentheses::parentheses, record::record, record_assignment::record_assignment,
+    string_literal::string_literal, tag::tag, unary_operator::unary_operator_expression,
+    ExpressionContext,
 };
 use ast::{Expression, IResult, ParserInput};
 use nom::{branch::alt, combinator::map};
@@ -22,6 +23,10 @@ pub fn basic_expression<'a>(
         map(record, Expression::Record),
         map(tag, Expression::Tag),
         map(move |input| function(context, input), Expression::Function),
+        map(
+            move |input| record_assignment(context, input),
+            Expression::RecordAssignment,
+        ),
     ))
 }
 
@@ -90,5 +95,14 @@ mod test {
             basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
         let (_, consumed) = result.unwrap();
         assert!(matches!(consumed, Expression::Function(_)));
+    }
+
+    #[test]
+    fn expression_can_be_a_record_assignment() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let result =
+            basic_expression(ExpressionContext::new().allow_newlines_in_expressions())(input);
+        let (_, consumed) = result.unwrap();
+        assert!(matches!(consumed, Expression::RecordAssignment(_)));
     }
 }

--- a/rust/parser/src/binary_operator_expression.rs
+++ b/rust/parser/src/binary_operator_expression.rs
@@ -255,8 +255,6 @@ pub fn binary_operator_expression<'a>(
 mod test {
     use super::*;
 
-    use ast::IdentifierValue;
-
     #[test]
     fn empty_input_is_not_binary_operator_expression() {
         let input = ParserInput::new("");

--- a/rust/parser/src/expression_context.rs
+++ b/rust/parser/src/expression_context.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExpressionContext {
+    pub indentation: usize,
+    pub allow_newlines_in_expressions: bool,
+}
+
+impl ExpressionContext {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            indentation: 0,
+            allow_newlines_in_expressions: false,
+        }
+    }
+
+    #[must_use]
+    /// Creates a new `ExpressionContext` whose expected level of indentation is one greater
+    /// than the object on which this method is invoked.
+    pub const fn increment_indentation(&self) -> Self {
+        Self {
+            indentation: self.indentation + 1,
+            allow_newlines_in_expressions: self.allow_newlines_in_expressions,
+        }
+    }
+
+    #[must_use]
+    /// Creates a copy of `self` that allows newlines in expressions.
+    pub const fn allow_newlines_in_expressions(&self) -> Self {
+        Self {
+            indentation: self.indentation,
+            allow_newlines_in_expressions: true,
+        }
+    }
+
+    #[must_use]
+    /// Creates a copy of `self` that disallows newlines in expressions.
+    pub const fn disallow_newlines_in_expressions(&self) -> Self {
+        Self {
+            indentation: self.indentation,
+            allow_newlines_in_expressions: false,
+        }
+    }
+}

--- a/rust/parser/src/file.rs
+++ b/rust/parser/src/file.rs
@@ -1,0 +1,12 @@
+use crate::document::document;
+use ast::{DocumentNode, ParserInput};
+use nom::{combinator::eof, sequence::terminated};
+
+pub fn parse_buri_file(source: &str) -> Result<DocumentNode, String> {
+    let input = ParserInput::new(source);
+    let result = terminated(document(), eof)(input);
+    match result {
+        Ok((_, document)) => Ok(document),
+        Err(error) => Err(error.to_string()),
+    }
+}

--- a/rust/parser/src/function_type.rs
+++ b/rust/parser/src/function_type.rs
@@ -105,7 +105,7 @@ mod test {
         } = function;
         assert_eq!(arguments.len(), 2);
         assert!(matches!(arguments[0], TypeExpression::List(_)));
-        assert!(matches!(arguments[1], TypeExpression::Tag(_)));
+        assert!(matches!(arguments[1], TypeExpression::TagGroup(_)));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod test {
         } = function;
         assert_eq!(arguments.len(), 2);
         assert!(matches!(arguments[0], TypeExpression::List(_)));
-        assert!(matches!(arguments[1], TypeExpression::Tag(_)));
+        assert!(matches!(arguments[1], TypeExpression::TagGroup(_)));
     }
 
     #[test]

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -4,6 +4,7 @@ mod binary_operator_or_if;
 mod block;
 mod document;
 mod expression_context;
+mod file;
 mod function;
 mod function_argument;
 mod function_type;
@@ -34,3 +35,4 @@ mod variable_declaration;
 
 use binary_operator_or_if::binary_operator_or_if as expression;
 use expression_context::ExpressionContext;
+pub use file::parse_buri_file;

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -21,6 +21,7 @@ mod list_type;
 mod newline;
 mod parentheses;
 mod record;
+mod record_assignment;
 mod record_type;
 mod string_literal;
 mod tag;

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -3,6 +3,7 @@ mod binary_operator_expression;
 mod binary_operator_or_if;
 mod block;
 mod document;
+mod expression_context;
 mod function;
 mod function_argument;
 mod function_type;
@@ -32,47 +33,4 @@ mod unary_operator;
 mod variable_declaration;
 
 use binary_operator_or_if::binary_operator_or_if as expression;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ExpressionContext {
-    pub indentation: usize,
-    pub allow_newlines_in_expressions: bool,
-}
-
-impl ExpressionContext {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            indentation: 0,
-            allow_newlines_in_expressions: false,
-        }
-    }
-
-    #[must_use]
-    /// Creates a new `ExpressionContext` whose expected level of indentation is one greater
-    /// than the object on which this method is invoked.
-    pub const fn increment_indentation(&self) -> Self {
-        Self {
-            indentation: self.indentation + 1,
-            allow_newlines_in_expressions: self.allow_newlines_in_expressions,
-        }
-    }
-
-    #[must_use]
-    /// Creates a copy of `self` that allows newlines in expressions.
-    pub const fn allow_newlines_in_expressions(&self) -> Self {
-        Self {
-            indentation: self.indentation,
-            allow_newlines_in_expressions: true,
-        }
-    }
-
-    #[must_use]
-    /// Creates a copy of `self` that disallows newlines in expressions.
-    pub const fn disallow_newlines_in_expressions(&self) -> Self {
-        Self {
-            indentation: self.indentation,
-            allow_newlines_in_expressions: false,
-        }
-    }
-}
+use expression_context::ExpressionContext;

--- a/rust/parser/src/record_assignment.rs
+++ b/rust/parser/src/record_assignment.rs
@@ -1,0 +1,141 @@
+use crate::{
+    expression_context::ExpressionContext,
+    identifier::identifier,
+    intra_expression_whitespace::intra_expression_whitespace,
+    record::{record_closing_delimiter, record_opening_delimiter, record_values},
+};
+use ast::{IResult, ParserInput, RecordAssignmentNode, RecordAssignmentValue};
+use nom::{
+    character::complete::char,
+    combinator::{consumed, map, opt},
+    sequence::{delimited, separated_pair, tuple},
+};
+
+pub fn record_assignment(
+    context: ExpressionContext,
+    input: ParserInput,
+) -> IResult<RecordAssignmentNode> {
+    map(
+        consumed(delimited(
+            record_opening_delimiter,
+            separated_pair(
+                identifier,
+                tuple((
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                    char('|'),
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                )),
+                record_values,
+            ),
+            record_closing_delimiter,
+        )),
+        |(consumed, (identifier, new_values))| RecordAssignmentNode {
+            source: consumed,
+            value: RecordAssignmentValue {
+                identifier,
+                new_values,
+            },
+        },
+    )(input)
+}
+
+#[cfg(test)]
+mod test {
+    use ast::Expression;
+
+    use super::*;
+
+    #[test]
+    fn assignment_can_parse() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parses_identifier_correctly() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.identifier.value.name, "hello");
+    }
+
+    #[test]
+    fn identifier_cannot_be_an_expression() {
+        let input = ParserInput::new("{hello()|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn identifier_cannot_be_type() {
+        let input = ParserInput::new("{Hello|name:\"world\"}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parses_one_value() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 1);
+    }
+
+    #[test]
+    fn parses_two_values_separated_by_a_comma() {
+        let input = ParserInput::new("{hello|name:\"world\",age:24}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 2);
+    }
+
+    #[test]
+    fn trailing_commas_do_not_parse_into_an_additional_item() {
+        let input = ParserInput::new("{hello|name:\"world\",}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(parsed.value.new_values.len(), 1);
+    }
+
+    #[test]
+    fn parses_value_identifier() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert_eq!(
+            parsed
+                .value
+                .new_values
+                .get(0)
+                .unwrap()
+                .identifier
+                .value
+                .name,
+            "name"
+        );
+    }
+
+    #[test]
+    fn parses_value_expression() {
+        let input = ParserInput::new("{hello|name:\"world\"}");
+        let (_, parsed) = record_assignment(ExpressionContext::new(), input).unwrap();
+        assert!(matches!(
+            parsed.value.new_values.get(0).unwrap().value,
+            Expression::StringLiteral(_)
+        ));
+    }
+
+    #[test]
+    fn can_have_spaces_anywhere() {
+        let input = ParserInput::new("{  hello  |  name  :  \"world\"  ,  }");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn can_have_newlines_anywhere() {
+        let input = ParserInput::new("{\n\nhello\n\n|\n\nname\n\n:\n\n\"world\"\n\n,\n\n}");
+        let result = record_assignment(ExpressionContext::new(), input);
+        assert!(result.is_ok());
+    }
+}

--- a/rust/parser/src/record_type.rs
+++ b/rust/parser/src/record_type.rs
@@ -72,8 +72,7 @@ pub fn record_type(input: ParserInput) -> IResult<RecordTypeNode> {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    use ast::{Expression, TypeExpression};
+    use ast::TypeExpression;
 
     #[test]
     fn empty_record_produces_empty_output() {

--- a/rust/parser/src/tag_group_type.rs
+++ b/rust/parser/src/tag_group_type.rs
@@ -92,4 +92,11 @@ mod test {
         let (_, parsed) = tag_group_type(input).unwrap();
         assert_eq!(parsed.value.len(), 2);
     }
+
+    #[test]
+    fn commas_are_not_parsed() {
+        let input = ParserInput::new("#hello,");
+        let (remainder, _) = tag_group_type(input).unwrap();
+        assert_eq!(remainder, ",");
+    }
 }

--- a/rust/parser/src/type_expression.rs
+++ b/rust/parser/src/type_expression.rs
@@ -1,6 +1,7 @@
+use crate::tag_group_type::tag_group_type;
 use crate::{
     function_type::function_type, list_type::list_type, record_type::record_type,
-    tag_type::tag_type, type_identifier::type_identifier,
+    type_identifier::type_identifier,
 };
 use ast::TypeExpression;
 use ast::{IResult, ParserInput};
@@ -10,7 +11,7 @@ pub fn type_expression(input: ParserInput) -> IResult<TypeExpression> {
     alt((
         map(type_identifier, TypeExpression::Identifier),
         map(list_type, |list| TypeExpression::List(Box::new(list))),
-        map(tag_type, TypeExpression::Tag),
+        map(tag_group_type, TypeExpression::TagGroup),
         map(record_type, TypeExpression::Record),
         map(function_type, TypeExpression::Function),
     ))(input)
@@ -42,10 +43,17 @@ mod test {
     }
 
     #[test]
-    fn a_tag_type_is_a_type_expression() {
+    fn a_single_tag_type_is_a_type_expression() {
         let input = ParserInput::new("#hello");
         let (_, expression) = type_expression(input.clone()).unwrap();
-        assert!(matches!(expression, TypeExpression::Tag(_)));
+        assert!(matches!(expression, TypeExpression::TagGroup(_)));
+    }
+
+    #[test]
+    fn a_tag_group_type_is_a_type_expression() {
+        let input = ParserInput::new("#hello | #world");
+        let (_, expression) = type_expression(input.clone()).unwrap();
+        assert!(matches!(expression, TypeExpression::TagGroup(_)));
     }
 
     #[test]

--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -43,6 +43,7 @@ pub const fn get_generic_type_id<'a>(input: &GenericExpression<'a>) -> GenericTy
         GenericExpression::Integer(node) => node.expression_type.type_id,
         GenericExpression::List(node) => node.expression_type.type_id,
         GenericExpression::Record(node) => node.expression_type.type_id,
+        GenericExpression::RecordAssignment(node) => node.expression_type.type_id,
         GenericExpression::StringLiteral(node) => node.expression_type.type_id,
         GenericExpression::Tag(node) => node.expression_type.type_id,
         GenericExpression::UnaryOperator(node) => node.expression_type.type_id,

--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -36,6 +36,7 @@ pub const fn get_generic_type_id<'a>(input: &GenericExpression<'a>) -> GenericTy
         GenericExpression::BinaryOperator(node) => node.expression_type.type_id,
         GenericExpression::Block(node) => node.expression_type.type_id,
         GenericExpression::Boolean(node) => node.expression_type.type_id,
+        GenericExpression::Declaration(node) => node.expression_type.type_id,
         GenericExpression::Function(node) => node.expression_type.type_id,
         GenericExpression::Identifier(node) => node.expression_type.type_id,
         GenericExpression::If(node) => node.expression_type.type_id,

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -1,14 +1,15 @@
 use crate::{
     ConcreteType, TypedBinaryOperatorExpression, TypedBlockExpression,
-    TypedBooleanLiteralExpression, TypedExpression, TypedFunctionExpression,
-    TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
-    TypedListExpression, TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
-    TypedUnaryOperatorExpression,
+    TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedExpression,
+    TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
+    TypedIntegerLiteralExpression, TypedListExpression, TypedRecordExpression,
+    TypedStringLiteralExpression, TypedTagExpression, TypedUnaryOperatorExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
 pub type ConcreteBlockExpression = TypedBlockExpression<ConcreteType>;
 pub type ConcreteBooleanExpression = TypedBooleanLiteralExpression<ConcreteType>;
+pub type ConcreteDeclarationExpression = TypedDeclarationExpression<ConcreteType>;
 pub type ConcreteFunctionExpression = TypedFunctionExpression<ConcreteType>;
 pub type ConcreteIdentifierExpression = TypedIdentifierExpression<ConcreteType>;
 pub type ConcreteIfExpression = TypedIfExpression<ConcreteType>;
@@ -23,12 +24,17 @@ pub type ConcreteExpression = TypedExpression<ConcreteType>;
 
 impl ConcreteExpression {
     #[must_use]
-    pub fn identifier_for_test(name: &str) -> Self {
-        Self::Identifier(Box::new(ConcreteIdentifierExpression {
+    pub fn raw_identifier_for_test(name: &str) -> ConcreteIdentifierExpression {
+        ConcreteIdentifierExpression {
             expression_type: ConcreteType::default_for_test(),
             name: name.to_string(),
             is_disregarded: false,
-        }))
+        }
+    }
+
+    #[must_use]
+    pub fn identifier_for_test(name: &str) -> Self {
+        Self::Identifier(Box::new(Self::raw_identifier_for_test(name)))
     }
 
     #[must_use]

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -46,4 +46,12 @@ impl ConcreteExpression {
             value: int,
         }))
     }
+
+    #[must_use]
+    pub fn block_for_test(expressions: Vec<Self>) -> Self {
+        Self::Block(Box::new(ConcreteBlockExpression {
+            expression_type: ConcreteType::default_for_test(),
+            contents: expressions,
+        }))
+    }
 }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -2,8 +2,9 @@ use crate::{
     ConcreteType, TypedBinaryOperatorExpression, TypedBlockExpression,
     TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedExpression,
     TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
-    TypedIntegerLiteralExpression, TypedListExpression, TypedRecordExpression,
-    TypedStringLiteralExpression, TypedTagExpression, TypedUnaryOperatorExpression,
+    TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
+    TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
+    TypedUnaryOperatorExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -16,6 +17,7 @@ pub type ConcreteIfExpression = TypedIfExpression<ConcreteType>;
 pub type ConcreteIntegerLiteralExpression = TypedIntegerLiteralExpression<ConcreteType>;
 pub type ConcreteListExpression = TypedListExpression<ConcreteType>;
 pub type ConcreteRecordExpression = TypedRecordExpression<ConcreteType>;
+pub type ConcreteRecordAssignmentExpression = TypedRecordAssignmentExpression<ConcreteType>;
 pub type ConcreteStringLiteralExpression = TypedStringLiteralExpression<ConcreteType>;
 pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -21,10 +21,6 @@ pub struct ConcreteTagUnionType {
     /// Map the name of a tag to an array of the types of its contained values.
     /// Tag with no contents maps to empty vec.
     pub tag_types: HashMap<String, Vec<ConcreteType>>,
-    /// Signifies of any tags in the tag union have content. If this is true,
-    /// then at least one tag in the tag union has content. If this is false,
-    /// then no tags in the tag union have content.
-    pub some_tags_have_content: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,9 +82,8 @@ impl ConcreteType {
     }
 
     #[must_use]
-    pub fn default_tag_union_for_test(some_tags_have_content: bool) -> Self {
+    pub fn default_tag_union_for_test() -> Self {
         Self::TagUnion(Box::new(ConcreteTagUnionType {
-            some_tags_have_content,
             tag_types: HashMap::new(),
         }))
     }

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -64,6 +64,13 @@ pub struct TypedListExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedRecordAssignmentExpression<T> {
+    pub expression_type: T,
+    pub identifier: TypedIdentifierExpression<T>,
+    pub contents: TypedRecordExpression<T>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedRecordExpression<T> {
     pub expression_type: T,
     pub contents: HashMap<String, TypedExpression<T>>,
@@ -101,6 +108,7 @@ pub enum TypedExpression<T> {
     Integer(Box<TypedIntegerLiteralExpression<T>>),
     List(Box<TypedListExpression<T>>),
     Record(Box<TypedRecordExpression<T>>),
+    RecordAssignment(Box<TypedRecordAssignmentExpression<T>>),
     StringLiteral(Box<TypedStringLiteralExpression<T>>),
     Tag(Box<TypedTagExpression<T>>),
     UnaryOperator(Box<TypedUnaryOperatorExpression<T>>),

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -1,7 +1,6 @@
 use ast::{BinaryOperatorSymbol, UnaryOperatorSymbol};
 use std::collections::HashMap;
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedBinaryOperatorExpression<T> {
     pub expression_type: T,
@@ -10,7 +9,6 @@ pub struct TypedBinaryOperatorExpression<T> {
     pub right_child: TypedExpression<T>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedBlockExpression<T> {
     pub expression_type: T,
@@ -23,7 +21,6 @@ pub struct TypedBooleanLiteralExpression<T> {
     pub value: bool,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedFunctionExpression<T> {
     pub expression_type: T,
@@ -38,7 +35,6 @@ pub struct TypedIdentifierExpression<T> {
     pub is_disregarded: bool,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedIfExpression<T> {
     pub expression_type: T,
@@ -53,14 +49,12 @@ pub struct TypedIntegerLiteralExpression<T> {
     pub value: u64,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedListExpression<T> {
     pub expression_type: T,
     pub contents: Vec<TypedExpression<T>>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedRecordExpression<T> {
     pub expression_type: T,
@@ -73,7 +67,6 @@ pub struct TypedStringLiteralExpression<T> {
     pub value: String,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedTagExpression<T> {
     pub expression_type: T,
@@ -81,7 +74,6 @@ pub struct TypedTagExpression<T> {
     pub contents: Vec<TypedExpression<T>>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedUnaryOperatorExpression<T> {
     pub expression_type: T,
@@ -89,7 +81,6 @@ pub struct TypedUnaryOperatorExpression<T> {
     pub child: TypedExpression<T>,
 }
 
-// TODO(nick): add this to JS backend
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedExpression<T> {
     BinaryOperator(Box<TypedBinaryOperatorExpression<T>>),

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -22,6 +22,14 @@ pub struct TypedBooleanLiteralExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedDeclarationExpression<T> {
+    pub expression_type: T,
+    pub identifier: TypedIdentifierExpression<T>,
+    pub value: TypedExpression<T>,
+    pub is_exported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedFunctionExpression<T> {
     pub expression_type: T,
     pub argument_names: Vec<String>,
@@ -86,6 +94,7 @@ pub enum TypedExpression<T> {
     BinaryOperator(Box<TypedBinaryOperatorExpression<T>>),
     Block(Box<TypedBlockExpression<T>>),
     Boolean(Box<TypedBooleanLiteralExpression<T>>),
+    Declaration(Box<TypedDeclarationExpression<T>>),
     Function(Box<TypedFunctionExpression<T>>),
     Identifier(Box<TypedIdentifierExpression<T>>),
     If(Box<TypedIfExpression<T>>),


### PR DESCRIPTION
Previously, we compiled tags to raw strings when none of the tags had any contents. However, this would occasionally produce bugs. Specifically, if you had a function where none of the tags required any contents, but you provided a tag that did have contents, then this would produce bugs as an array is not the same type as a string.

For prod builds, we can still use this optimization. But for incremental developer builds, we can never guarantee this optimization is bug free.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unneeded-import","parentHead":"412885b2a075a68cb8f3f7495c347c94e4210d5a","parentPull":74,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unneeded-import","parentHead":"412885b2a075a68cb8f3f7495c347c94e4210d5a","parentPull":74,"trunk":"main"}
```
-->
