### PR TITLE
Print JS document

### DIFF
--- a/rust/js_backend/src/expression/declaration.rs
+++ b/rust/js_backend/src/expression/declaration.rs
@@ -2,14 +2,9 @@ use crate::{expression::print_expression, identifier::print_identifier};
 use typed_ast::ConcreteDeclarationExpression;
 
 pub fn print_declaration(declaration: &ConcreteDeclarationExpression) -> String {
-    let export = if declaration.is_exported {
-        "export "
-    } else {
-        ""
-    };
     let identifier = print_identifier(&declaration.identifier);
     let value = print_expression(&declaration.value);
-    format!("{export}const {identifier}={value}")
+    format!("const {identifier}={value}")
 }
 
 #[cfg(test)]
@@ -24,7 +19,6 @@ mod test {
             expression_type: ConcreteType::default_integer_for_test(),
             identifier: ConcreteExpression::raw_identifier_for_test("foo"),
             value: ConcreteExpression::integer_for_test(42),
-            is_exported: false,
         };
         assert_eq!(print_declaration(&declaration), "const foo=42");
     }
@@ -35,19 +29,7 @@ mod test {
             expression_type: ConcreteType::default_string_for_test(),
             identifier: ConcreteExpression::raw_identifier_for_test("hello"),
             value: ConcreteExpression::string_for_test("world"),
-            is_exported: false,
         };
         assert_eq!(print_declaration(&declaration), "const hello=\"world\"");
-    }
-
-    #[test]
-    fn can_export_declarations() {
-        let declaration = ConcreteDeclarationExpression {
-            expression_type: ConcreteType::default_integer_for_test(),
-            identifier: ConcreteExpression::raw_identifier_for_test("foo"),
-            value: ConcreteExpression::integer_for_test(42),
-            is_exported: true,
-        };
-        assert_eq!(print_declaration(&declaration), "export const foo=42");
     }
 }

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -185,7 +185,6 @@ mod test {
                 expression_type: ConcreteType::default_integer_for_test(),
                 identifier: ConcreteExpression::raw_identifier_for_test("foo"),
                 value: ConcreteExpression::integer_for_test(42),
-                is_exported: false,
             }));
         assert_eq!(print_expression(&declaration), "const foo=42");
     }

--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -1,4 +1,26 @@
+use expression::print_expression;
+use imports::print_imports;
+use typed_ast::{ConcreteType, TypedDocument};
+
 mod expression;
 mod identifier;
 mod imports;
 mod literals;
+
+#[must_use]
+pub fn print_js_document(document: &TypedDocument<ConcreteType>) -> String {
+    let mut result = String::new();
+    result.push_str(&print_imports(&document.imports));
+    for declaration in &document.variable_declarations {
+        result.push('\n');
+        if declaration.is_exported {
+            result.push_str("export ");
+        }
+        // TODO(B-218): Clean this up to use the print_declaration method instead
+        // manually rewriting that code here.
+        result.push_str(&declaration.declaration.identifier_name);
+        result.push('=');
+        result.push_str(&print_expression(&declaration.declaration.expression));
+    }
+    result
+}

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -26,7 +26,6 @@ pub struct TypedDeclarationExpression<T> {
     pub expression_type: T,
     pub identifier: TypedIdentifierExpression<T>,
     pub value: TypedExpression<T>,
-    pub is_exported: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Few comments:

1. The JS backend will not print out the type information. That's both unnecessary and invalid JS.
2. The JS backend intentionally does not print out top-level expressions. This is under a few assumptions. First, that none of these top-level expressions are variable declarations (because they otherwise would be marked as such). Second, that the Rust version of Buri remains pure and does not include tasks. If both of those assumptions are true, then top-level expressions cannot be referenced anywhere and do not produce any output.
3. It's not ideal that I couldn't reuse the existing `print_declaration` function for these top-level declarations. However, I'm ok with having a little bit more technical debt here given that this code is temporary and that the true solution will likely involve unifying the tree structure across all stages of the compilation pipeline. That just seems like too much work for now so I opted to create those declarations manually.
4. The lack of tests is intentional. Because any such test would require building up an entire document tree then ensuring the entire output is best, it seems like our planned end-to-end tests both entirely cover the purpose of any unit tests here and that any such unit tests would take far more effort to setup than to actually verify. The code is simple enough as well that I don't feel like adding many tests would sufficiently reduce bugs.
5. Because the top level imports let you know whenever something is imported and a declaration that's not top level can never be exported, I removed the export code for the declarations.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
