### PR TITLE
Add entry points for type checker and type resolver

### DIFF
--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -2,8 +2,8 @@ use crate::GenericTypeId;
 use ast::ParserInput;
 use typed_ast::{
     TypedBinaryOperatorExpression, TypedBlockExpression, TypedBooleanLiteralExpression,
-    TypedExpression, TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
-    TypedIntegerLiteralExpression, TypedListExpression, TypedRecordExpression,
+    TypedDocument, TypedExpression, TypedFunctionExpression, TypedIdentifierExpression,
+    TypedIfExpression, TypedIntegerLiteralExpression, TypedListExpression, TypedRecordExpression,
     TypedStringLiteralExpression, TypedTagExpression, TypedUnaryOperatorExpression,
 };
 
@@ -30,6 +30,7 @@ pub type GenericTagExpression<'a> = TypedTagExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
+pub type GenericDocument<'a> = TypedDocument<'a, GenericSourcedType<'a>>;
 
 pub const fn get_generic_type_id<'a>(input: &GenericExpression<'a>) -> GenericTypeId {
     match input {

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -5,3 +5,19 @@ mod type_schema;
 mod type_schema_substitutions;
 
 type GenericTypeId = usize;
+
+use ast::DocumentNode;
+use generic_nodes::GenericDocument;
+use typed_ast::ConcreteDocument;
+
+#[allow(clippy::needless_pass_by_value)]
+// TODO(aaron) clarify error type, and move function definition to separate file.
+pub fn apply_constraints(input: DocumentNode) -> Result<GenericDocument, ()> {
+    unimplemented!();
+}
+
+#[allow(clippy::needless_pass_by_value)]
+// TODO(aaron) clarify error type, and move function definition to separate file.
+pub fn resolve_concrete_types(input: GenericDocument) -> Result<ConcreteDocument, ()> {
+    unimplemented!();
+}

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -1,6 +1,6 @@
 use crate::{
     ConcreteType, TypedBinaryOperatorExpression, TypedBlockExpression,
-    TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedExpression,
+    TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedDocument, TypedExpression,
     TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
@@ -23,6 +23,7 @@ pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
+pub type ConcreteDocument<'a> = TypedDocument<'a, ConcreteType>;
 
 impl ConcreteExpression {
     #[must_use]


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
