### PR TITLE
Add e2e testing for compiled JS output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .DS_Store
 node_modules
+
+.buri/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "compiler"
+version = "0.1.0"
+dependencies = [
+ "ast",
+ "js_backend",
+ "parser",
+ "type_checker",
+]
+
+[[package]]
+name = "e2e"
+version = "0.1.0"
+dependencies = [
+ "compiler",
+ "walkdir",
+]
+
+[[package]]
 name = "js_backend"
 version = "0.1.0"
 dependencies = [
@@ -67,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "type_checker"
 version = "0.1.0"
 dependencies = [
@@ -80,3 +107,45 @@ version = "0.1.0"
 dependencies = [
  "ast",
 ]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 
 members = [
     "rust/ast",
+    "rust/compiler",
+    "rust/e2e",
     "rust/parser",
     "rust/js_backend",
     "rust/type_checker",
@@ -11,6 +13,7 @@ members = [
 [workspace.dependencies]
 nom = "7.1.3"
 nom_locate = "4.1.0"
+walkdir = "2.3.2"
 
 [toolchain]
 channel = "1.66.0"

--- a/rust/compiler/Cargo.toml
+++ b/rust/compiler/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "compiler"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ast = { path = "../ast" }
+parser = { path = "../parser" }
+js_backend = { path = "../js_backend" }
+type_checker = { path = "../type_checker" }

--- a/rust/compiler/src/lib.rs
+++ b/rust/compiler/src/lib.rs
@@ -1,0 +1,32 @@
+use js_backend::print_js_document;
+use parser::parse_buri_file;
+use type_checker::{apply_constraints, resolve_concrete_types};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompilationError {
+    ParseError(String),
+    TypeError(()),
+    TypeResolutionError(()),
+}
+
+/// Compiles a single Buri file. Do not use to compile Buri programs with
+/// multiple files.
+///
+/// This function accepts the string contents of the Buri file, then returns
+/// the compiled JS output (or an error if the input is invalid). The caller
+/// must read the Buri file itself—this function does not do that.
+pub fn compile_buri_file(contents: &str) -> Result<String, CompilationError> {
+    let parsed_ast = match parse_buri_file(contents) {
+        Ok(ast) => ast,
+        Err(error) => return Err(CompilationError::ParseError(error)),
+    };
+    let generic_document = match apply_constraints(parsed_ast) {
+        Ok(document) => document,
+        Err(error) => return Err(CompilationError::TypeError(error)),
+    };
+    let concrete_document = match resolve_concrete_types(generic_document) {
+        Ok(document) => document,
+        Err(error) => return Err(CompilationError::TypeResolutionError(error)),
+    };
+    Ok(print_js_document(&concrete_document))
+}

--- a/rust/e2e/Cargo.toml
+++ b/rust/e2e/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "e2e"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+compiler = { path = "../compiler" }
+walkdir.workspace = true

--- a/rust/e2e/src/lib.rs
+++ b/rust/e2e/src/lib.rs
@@ -1,0 +1,116 @@
+use compiler::compile_buri_file;
+use std::io::Write;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+use walkdir::WalkDir;
+
+fn get_test_directory() -> Result<PathBuf, ()> {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/js"))
+        .canonicalize()
+        .map_or(Err(()), Ok)
+}
+
+fn get_valid_directory(path: &Path) -> PathBuf {
+    path.join("valid")
+}
+
+fn get_invalid_directory(path: &Path) -> PathBuf {
+    path.join("invalid")
+}
+
+fn get_directories() -> Result<(PathBuf, PathBuf), ()> {
+    let test_directory = get_test_directory()?;
+    Ok((
+        get_valid_directory(&test_directory),
+        get_invalid_directory(&test_directory),
+    ))
+}
+
+/// Returns a vector of all file paths that could be built (when they
+/// shouldn't).
+#[allow(clippy::unwrap_used)] // this is essentially a test
+fn build_valid_files(directory: &Path) -> Vec<String> {
+    let files = WalkDir::new(directory)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|item| {
+            item.path()
+                .extension()
+                .map_or(false, |os_str| os_str.eq_ignore_ascii_case("buri"))
+        });
+    let mut failed_builds = Vec::new();
+    for file_path in files {
+        if let Ok(contents) = std::fs::read_to_string(file_path.path()) {
+            compile_buri_file(&contents).map_or_else(
+                |_| failed_builds.push(format!("{file_path:?}")),
+                |new_contents| {
+                    let mut output_path =
+                        PathBuf::from(".buri/dist").join(PathBuf::from(file_path.path()));
+                    output_path.set_extension("mjs");
+                    let mut output = File::create(output_path).unwrap();
+                    write!(output, "{new_contents}").unwrap();
+                    println!("PASS: {file_path:?} built as expected");
+                },
+            );
+        } else {
+            failed_builds.push(format!("{file_path:?}"));
+        };
+    }
+    failed_builds
+}
+
+/// Returns a vector of all file paths that could be built (when they
+/// shouldn't).
+fn build_invalid_files(directory: &Path) -> Vec<String> {
+    let files = WalkDir::new(directory)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|item| {
+            item.path()
+                .extension()
+                .map_or(false, |os_str| os_str.eq_ignore_ascii_case("buri"))
+        });
+    let mut successful_builds = Vec::new();
+    for file_path in files {
+        if let Ok(contents) = std::fs::read_to_string(file_path.path()) {
+            match compile_buri_file(&contents) {
+                Ok(_) => successful_builds.push(format!("{file_path:?}")),
+                Err(_) => println!("PASS: {file_path:?} failed to build as expected"),
+            };
+        } else {
+            successful_builds.push(format!("{file_path:?}"));
+        };
+    }
+    successful_builds
+}
+
+#[allow(clippy::result_unit_err)] // we just care if it passes or errors
+pub fn build_tests() -> Result<(), ()> {
+    let (valid_directory, invalid_directory) = get_directories()?;
+
+    let invalid_test_errors = build_invalid_files(&invalid_directory);
+    let valid_test_errors = build_valid_files(&valid_directory);
+    println!("\n\n");
+    for error in valid_test_errors {
+        println!("FAIL: {error} could not be built");
+    }
+    println!("\n");
+    for error in invalid_test_errors {
+        println!("FAIL: {error} unexpectedly built successfully");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // TODO(B-220): remove this ignore statement to ensure the e2e tests build.
+    #[test]
+    #[ignore]
+    fn testing() {
+        assert!(build_tests().is_ok());
+    }
+}

--- a/rust/e2e/src/main.rs
+++ b/rust/e2e/src/main.rs
@@ -1,0 +1,5 @@
+use e2e::build_tests;
+
+fn main() -> Result<(), ()> {
+    build_tests()
+}

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,0 +1,42 @@
+# JS tests
+
+This folder contains the end-to-end tests for the Buri JS output. This doc outlines how to use and run these tests.
+
+## Running the tests
+
+From the repo root, run the following commands:
+
+```bash
+cargo run rust/e2e # build the JS outputs
+bun wiptest # test the JS outputs
+```
+
+If both commands succeed, the tests passed!
+
+## Adding a new test
+
+This directory contains two types of tests. First, in the `/tests/js/valid/` directory are all tests for valid Buri code. We expect Buri code in here to both compile and function correctly. Second, in the `/tests/js/invalid/` directory are all tests for invalid Buri code. We expect all Buri code in here to fail to compile.
+
+### Adding a new valid test
+
+Use the following steps to add a new valid test:
+
+1. Add a new Buri file to the `/tests/js/valid/` directory (subdirectories are allowed)
+2. Write the Buri code you want to test inside this file
+3. In the same location of Buri file, add a new file with the extension `.test.js`. By convention, the name of this file should match the name of the Buri file. So if you added a file called `foo.buri`, you should add a file called `foo.test.js`.
+4. In this JS file, import anything you exported from the Buri file (except for types). The identifiers are the same. However, ensure you update the file path to start with `.buri/dist/tests/js/valid/` instead of `tests/js/valid/` and change the file extension to `.mjs` instead of `.buri`.
+5. In this JS file, write any assertions you want to test using Bun's testing framework. While the testing framework isn't well documented, reference [Jest](https://jestjs.io/docs/en/using-matchers) since it's very similar to Bun's testing framework.
+
+Once you've finished writing your test, run the tests as described above. If the test passes, you're done!
+
+#### Debugging a valid test
+
+If a test fails, here's a few steps you should use to debug it:
+
+1. If the Buri file fails to build, ensure it's written correctly. Unfortunately we don't have great error messages yet, so you may need to debug it manually. It's also possible there's a bug in the compiler, so feel free to open an issue if you think that's the case.
+2. If the Bun test fails, check Bun's terminal output. Perhaps it'll give you a hint as to what went wrong (e.g., function returned `25` instead of `42`).
+3. If the Bun test fails, you can also check the JS output. All JS files are located in `.buri/dist/` and have the same relative folder structure as the Buri files in the test folder.
+
+### Adding a new invalid test
+
+To add a new invalid test, just add a new file to the `/tests/js/invalid/` directory with the `.buri` extension. The file should contain the invalid Buri code, and can go in subdirectories of `/tests/js/invalid/`. The testing framework will automatically pick up the new file and ensure it fails to compile.

--- a/tests/js/invalid/type-error/operators/add.buri
+++ b/tests/js/invalid/type-error/operators/add.buri
@@ -1,0 +1,1 @@
+"hello world" + 1

--- a/tests/js/valid/integers/unsigned.buri
+++ b/tests/js/valid/integers/unsigned.buri
@@ -1,0 +1,8 @@
+@export
+one = 1
+
+@export
+two = 2
+
+@export
+onePlusTwo = 1 + 2

--- a/tests/js/valid/integers/unsigned.test.js
+++ b/tests/js/valid/integers/unsigned.test.js
@@ -1,0 +1,19 @@
+import {
+    one,
+    onePlusTwo,
+    two,
+} from ".buri/dist/tests/js/valid/integers/unsigned.mjs"
+
+import { expect, it } from "bun:test"
+
+it("a literal with the value of 1 should be equal to 1", () => {
+    expect(one).toBe(1)
+})
+
+it("a literal with the value of 2 should be equal to 2", () => {
+    expect(two).toBe(2)
+})
+
+it("one plus two equals three", () => {
+    expect(onePlusTwo).toBe(3)
+})


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
