### PR TITLE
Add FunctionApplication translation to BinaryOperator translator

### DIFF
--- a/rust/js_backend/src/expression/function_arguments.rs
+++ b/rust/js_backend/src/expression/function_arguments.rs
@@ -1,0 +1,45 @@
+use super::print_expression;
+use typed_ast::ConcreteExpression;
+
+pub fn print_function_arguments(arguments: &Vec<ConcreteExpression>) -> String {
+    let mut result = String::new();
+    result.push('(');
+    for (index, item) in arguments.iter().enumerate() {
+        result.push_str(&print_expression(item));
+        if index < arguments.len() - 1 {
+            result.push(',');
+        }
+    }
+    result.push(')');
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use typed_ast::ConcreteExpression;
+
+    #[test]
+    fn can_print_integer_arguments() {
+        let arguments = vec![
+            ConcreteExpression::integer_for_test(42),
+            ConcreteExpression::integer_for_test(43),
+        ];
+        assert_eq!(print_function_arguments(&arguments), "(42,43)");
+    }
+
+    #[test]
+    fn does_not_include_comma_with_one_item() {
+        let arguments = vec![ConcreteExpression::integer_for_test(42)];
+        assert_eq!(print_function_arguments(&arguments), "(42)");
+    }
+
+    #[test]
+    fn can_print_string_arguments() {
+        let arguments = vec![
+            ConcreteExpression::string_for_test("foo"),
+            ConcreteExpression::string_for_test("bar"),
+        ];
+        assert_eq!(print_function_arguments(&arguments), "(\"foo\",\"bar\")");
+    }
+}

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -2,6 +2,7 @@ mod binary_operator;
 mod block;
 mod boolean;
 mod declaration;
+mod function_arguments;
 mod function_declaration;
 mod if_expression;
 mod list;
@@ -40,6 +41,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         }
         ConcreteExpression::Boolean(boolean) => boolean::print_boolean(boolean),
         ConcreteExpression::Declaration(declaration) => declaration::print_declaration(declaration),
+        ConcreteExpression::FunctionArguments(arguments) => {
+            function_arguments::print_function_arguments(arguments)
+        }
     }
 }
 

--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -39,6 +39,7 @@ pub const fn get_generic_type_id<'a>(input: &GenericExpression<'a>) -> GenericTy
         GenericExpression::Boolean(node) => node.expression_type.type_id,
         GenericExpression::Declaration(node) => node.expression_type.type_id,
         GenericExpression::Function(node) => node.expression_type.type_id,
+        GenericExpression::FunctionArguments(_) => unreachable!(),
         GenericExpression::Identifier(node) => node.expression_type.type_id,
         GenericExpression::If(node) => node.expression_type.type_id,
         GenericExpression::Integer(node) => node.expression_type.type_id,

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -102,6 +102,7 @@ pub enum TypedExpression<T> {
     Boolean(Box<TypedBooleanLiteralExpression<T>>),
     Declaration(Box<TypedDeclarationExpression<T>>),
     Function(Box<TypedFunctionExpression<T>>),
+    FunctionArguments(Vec<TypedExpression<T>>),
     Identifier(Box<TypedIdentifierExpression<T>>),
     If(Box<TypedIfExpression<T>>),
     Integer(Box<TypedIntegerLiteralExpression<T>>),


### PR DESCRIPTION
Also adds function arguments print function to JS output.

Also splits `translate_binary_operator` due to cranky error.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
