### PR TITLE
Import the prelude in all JS output files

### DIFF
--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -9,7 +9,7 @@ mod literals;
 
 #[must_use]
 pub fn print_js_document(document: &TypedDocument<ConcreteType>) -> String {
-    let mut result = String::new();
+    let mut result = String::from("import 'packages/std/prelude/index.js'\n");
     result.push_str(&print_imports(&document.imports));
     for declaration in &document.variable_declarations {
         result.push('\n');


### PR DESCRIPTION
This may be a controversial change.

In short, we'll need the prelude for Buri to function correctly. That means we'll need to have a way to import this prelude for every single file in the developer build (the rules of JS may be slightly different, but the conservative approach for now is to import it everywhere).

For any Buri file compiled and run in this repo, we can just hardcode the link as I did in this PR. However, we'll need to find a way to distribute this prelude when we distribute the compiler. Since I suspect that won't happen until the bootstrapped version, I think it's acceptable to hardcode the prelude import for now. In the future, we'll need to figure out a sustainable way to fix this.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
