### PR TITLE
Add TODO(aaron) to obvious gaps

### DIFF
--- a/rust/type_checker/src/apply_constraints.rs
+++ b/rust/type_checker/src/apply_constraints.rs
@@ -47,8 +47,10 @@ pub fn apply_constraints(input: DocumentNode) -> Result<GenericDocument, ()> {
     }
     Ok(GenericDocument {
         imports: input.value.imports,
+        // TODO(aaron) add type declarations to return value
         type_declarations: vec![],
         variable_declarations: variable_declarations,
+        // TODO(aaron) add top level expressions to return value
         expressions: vec![],
     })
 }

--- a/rust/type_checker/src/apply_constraints.rs
+++ b/rust/type_checker/src/apply_constraints.rs
@@ -1,0 +1,54 @@
+use crate::{
+    generic_nodes::{
+        get_generic_type_id, GenericDocument, GenericSourcedType, GenericVariableDeclaration,
+    },
+    parsed_expression_to_generic_expression::translate_parsed_expression_to_generic_expression,
+    type_schema::TypeSchema,
+    type_schema_substitutions::TypeSchemaSubstitutions,
+};
+use ast::{DocumentNode, ParsedNode, TopLevelDeclaration, VariableDeclarationValue};
+use typed_ast::TypedVariableDeclaration;
+
+fn translate_variable_declaration<'a>(
+    input: TopLevelDeclaration<ParsedNode<'a, VariableDeclarationValue<'a>>>,
+) -> Result<TopLevelDeclaration<GenericVariableDeclaration<'a>>, ()> {
+    let identifier_name = input.declaration.value.identifier.value.name;
+    let mut schema = TypeSchema::new();
+    let mut substitutions = TypeSchemaSubstitutions::new();
+    let expression = translate_parsed_expression_to_generic_expression(
+        &mut schema,
+        &mut substitutions,
+        input.declaration.value.expression,
+    )?;
+    let type_id = get_generic_type_id(&expression);
+    Ok(TopLevelDeclaration {
+        declaration: GenericVariableDeclaration {
+            declaration: TypedVariableDeclaration {
+                declaration_type: GenericSourcedType {
+                    type_id,
+                    source_of_type: input.declaration.source,
+                },
+                identifier_name,
+                expression,
+            },
+            schema,
+            substitutions,
+        },
+        is_exported: input.is_exported,
+    })
+}
+
+pub fn apply_constraints(input: DocumentNode) -> Result<GenericDocument, ()> {
+    let mut variable_declarations: Vec<TopLevelDeclaration<GenericVariableDeclaration>> =
+        Vec::new();
+    variable_declarations.reserve_exact(input.value.variable_declarations.len());
+    for variable_declaration in input.value.variable_declarations {
+        variable_declarations.push(translate_variable_declaration(variable_declaration)?);
+    }
+    Ok(GenericDocument {
+        imports: input.value.imports,
+        type_declarations: vec![],
+        variable_declarations: variable_declarations,
+        expressions: vec![],
+    })
+}

--- a/rust/type_checker/src/constraints.rs
+++ b/rust/type_checker/src/constraints.rs
@@ -1,6 +1,6 @@
 use crate::GenericTypeId;
 use std::collections::HashMap;
-use typed_ast::ConcreteType;
+use typed_ast::{ConcreteType, PrimitiveType};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Constrain that a generic type is a tag union
@@ -37,8 +37,8 @@ pub struct HasMethodConstraint {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Constraint {
-    /// Constrain that a generic type be equal to some concrete type.
-    EqualToConcrete(ConcreteType),
+    /// Constrain that a generic type be equal to some primitive type.
+    EqualToPrimitive(PrimitiveType),
     /// Constrain that a generic type is a list whose contents have a particular type.
     ListOfType(GenericTypeId),
     /// Constrain that a generic type is a tag union with at least a given set of tags.

--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -1,12 +1,16 @@
-use crate::GenericTypeId;
-use ast::ParserInput;
+use crate::{
+    type_schema::TypeSchema, type_schema_substitutions::TypeSchemaSubstitutions, GenericTypeId,
+};
+use ast::{ImportNode, ParserInput, TopLevelDeclaration};
 use typed_ast::{
     TypedBinaryOperatorExpression, TypedBlockExpression, TypedBooleanLiteralExpression,
     TypedDocument, TypedExpression, TypedFunctionExpression, TypedIdentifierExpression,
     TypedIfExpression, TypedIntegerLiteralExpression, TypedListExpression, TypedRecordExpression,
-    TypedStringLiteralExpression, TypedTagExpression, TypedUnaryOperatorExpression,
+    TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclaration,
+    TypedUnaryOperatorExpression, TypedVariableDeclaration,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenericSourcedType<'a> {
     /// The derived type of an expression.
     pub type_id: GenericTypeId,
@@ -30,7 +34,21 @@ pub type GenericTagExpression<'a> = TypedTagExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
-pub type GenericDocument<'a> = TypedDocument<'a, GenericSourcedType<'a>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericVariableDeclaration<'a> {
+    pub declaration: TypedVariableDeclaration<GenericSourcedType<'a>>,
+    pub schema: TypeSchema,
+    pub substitutions: TypeSchemaSubstitutions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericDocument<'a> {
+    pub imports: Vec<ImportNode<'a>>,
+    pub type_declarations: Vec<TopLevelDeclaration<TypedTypeDeclaration<GenericSourcedType<'a>>>>,
+    pub variable_declarations: Vec<TopLevelDeclaration<GenericVariableDeclaration<'a>>>,
+    pub expressions: Vec<TypedExpression<GenericSourcedType<'a>>>,
+}
 
 pub const fn get_generic_type_id<'a>(input: &GenericExpression<'a>) -> GenericTypeId {
     match input {

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -1,3 +1,4 @@
+mod apply_constraints;
 mod constraints;
 mod generic_nodes;
 mod parsed_expression_to_generic_expression;
@@ -6,15 +7,10 @@ mod type_schema_substitutions;
 
 type GenericTypeId = usize;
 
-use ast::DocumentNode;
+pub use apply_constraints::apply_constraints;
+
 use generic_nodes::GenericDocument;
 use typed_ast::ConcreteDocument;
-
-#[allow(clippy::needless_pass_by_value)]
-// TODO(aaron) clarify error type, and move function definition to separate file.
-pub fn apply_constraints(input: DocumentNode) -> Result<GenericDocument, ()> {
-    unimplemented!();
-}
 
 #[allow(clippy::needless_pass_by_value)]
 // TODO(aaron) clarify error type, and move function definition to separate file.

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -2,18 +2,11 @@ mod apply_constraints;
 mod constraints;
 mod generic_nodes;
 mod parsed_expression_to_generic_expression;
+mod resolve_concrete_types;
 mod type_schema;
 mod type_schema_substitutions;
 
 type GenericTypeId = usize;
 
 pub use apply_constraints::apply_constraints;
-
-use generic_nodes::GenericDocument;
-use typed_ast::ConcreteDocument;
-
-#[allow(clippy::needless_pass_by_value)]
-// TODO(aaron) clarify error type, and move function definition to separate file.
-pub fn resolve_concrete_types(input: GenericDocument) -> Result<ConcreteDocument, ()> {
-    unimplemented!();
-}
+pub use resolve_concrete_types::resolve_concrete_types;

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -302,6 +302,7 @@ fn translate_block<'a>(
     })
 }
 
+// TODO(aaron) handle variable lookup
 fn translate_identifier<'a>(
     schema: &mut TypeSchema,
     substitutions: &mut TypeSchemaSubstitutions,

--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -20,11 +20,11 @@ use std::collections::HashMap;
 use typed_ast::{ConcreteType, PrimitiveType};
 
 const fn constrain_equal_to_num() -> Constraint {
-    Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Num))
+    Constraint::EqualToPrimitive(PrimitiveType::Num)
 }
 
 const fn constrain_equal_to_str() -> Constraint {
-    Constraint::EqualToConcrete(ConcreteType::Primitive(PrimitiveType::Str))
+    Constraint::EqualToPrimitive(PrimitiveType::Str)
 }
 
 fn constrain_at_least_true() -> Constraint {

--- a/rust/type_checker/src/resolve_concrete_types.rs
+++ b/rust/type_checker/src/resolve_concrete_types.rs
@@ -15,6 +15,7 @@ use typed_ast::{
     ConcreteType, ConcreteVariableDeclaration, PrimitiveType, TypedVariableDeclaration,
 };
 
+// TODO(aaron) return correct tag for non-boolean
 fn resolve_tag_union_type(constraint_vec: &Vec<Constraint>) -> ConcreteType {
     for constraint in constraint_vec {
         match constraint {
@@ -90,14 +91,17 @@ fn resolve_generic_type(
         BroadType::Unknown => Ok(ConcreteType::Primitive(PrimitiveType::CompilerBoolean)),
         BroadType::Num => Ok(ConcreteType::Primitive(PrimitiveType::Num)),
         BroadType::Str => Ok(ConcreteType::Primitive(PrimitiveType::Str)),
+        // TODO(aaron) add specific function types to return value
         BroadType::Function => Ok(ConcreteType::Function(Box::new(ConcreteFunctionType {
             argument_types: vec![],
             return_type: None,
         }))),
         BroadType::TagUnion => Ok(resolve_tag_union_type(constraint_vec)),
+        // TODO(aaron) add specific element type to return value
         BroadType::List => Ok(ConcreteType::List(Box::new(ConcreteListType {
             element_type: ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
         }))),
+        // TODO(aaron) add field names and types to return value
         BroadType::Record => Ok(ConcreteType::Record(Box::new(ConcreteRecordType {
             field_types: HashMap::new(),
         }))),
@@ -137,6 +141,7 @@ fn resolve_expression<'a>(
                     substitutions,
                     generic_block.expression_type.type_id,
                 )?,
+                // TODO(aaron) add block contents to return value
                 contents: vec![],
             },
         ))),
@@ -179,10 +184,12 @@ fn resolve_expression<'a>(
                     substitutions,
                     generic_function.expression_type.type_id,
                 )?,
+                // TODO(aaron) add argument names to return value
                 argument_names: vec![],
                 body: resolve_expression(simplified_schema, substitutions, generic_function.body)?,
             }),
         )),
+        // TODO(aaron) GenericExpression::FunctionArguments
         GenericExpression::Identifier(generic_identifier) => Ok(ConcreteExpression::Identifier(
             Box::new(ConcreteIdentifierExpression {
                 expression_type: resolve_generic_type(
@@ -194,6 +201,7 @@ fn resolve_expression<'a>(
                 is_disregarded: generic_identifier.is_disregarded,
             }),
         )),
+        // TODO(aaron) GenericExpression::If
         GenericExpression::Integer(generic_integer) => Ok(ConcreteExpression::Integer(Box::new(
             ConcreteIntegerLiteralExpression {
                 expression_type: resolve_generic_type(
@@ -204,6 +212,12 @@ fn resolve_expression<'a>(
                 value: generic_integer.value,
             },
         ))),
+        // TODO(aaron) GenericExpression::List
+        // TODO(aaron) GenericExpression::Record
+        // TODO(aaron) GenericExpression::RecordAssignment
+        // TODO(aaron) GenericExpression::StringLiteral
+        // TODO(aaron) GenericExpression::Tag
+        // TODO(aaron) GenericExpression::UnaryOperator
         _ => unimplemented!(),
     }
 }
@@ -244,8 +258,10 @@ pub fn resolve_concrete_types(input: GenericDocument) -> Result<ConcreteDocument
         .collect();
     Ok(ConcreteDocument {
         imports: input.imports,
+        // TODO(aaron) add type declarations to return value
         type_declarations: vec![],
         variable_declarations: variable_declarations?,
+        // TODO(aaron) add top level expressions to return value
         expressions: vec![],
     })
 }

--- a/rust/type_checker/src/resolve_concrete_types.rs
+++ b/rust/type_checker/src/resolve_concrete_types.rs
@@ -1,0 +1,251 @@
+use crate::{
+    constraints::Constraint,
+    generic_nodes::{GenericDocument, GenericExpression, GenericVariableDeclaration},
+    type_schema::TypeSchema,
+    type_schema_substitutions::TypeSchemaSubstitutions,
+    GenericTypeId,
+};
+use ast::TopLevelDeclaration;
+use std::collections::HashMap;
+use typed_ast::{
+    ConcreteBinaryOperatorExpression, ConcreteBlockExpression, ConcreteBooleanExpression,
+    ConcreteDeclarationExpression, ConcreteDocument, ConcreteExpression,
+    ConcreteFunctionExpression, ConcreteFunctionType, ConcreteIdentifierExpression,
+    ConcreteIntegerLiteralExpression, ConcreteListType, ConcreteRecordType, ConcreteTagUnionType,
+    ConcreteType, ConcreteVariableDeclaration, PrimitiveType, TypedVariableDeclaration,
+};
+
+fn resolve_tag_union_type(constraint_vec: &Vec<Constraint>) -> ConcreteType {
+    for constraint in constraint_vec {
+        match constraint {
+            Constraint::HasTag(tag) => {
+                if (tag.tag_name != "true" && tag.tag_name != "false")
+                    || tag.tag_content_types.len() > 0
+                {
+                    return ConcreteType::TagUnion(Box::new(ConcreteTagUnionType {
+                        tag_types: HashMap::new(),
+                    }));
+                }
+            }
+            _ => {}
+        }
+    }
+    ConcreteType::Primitive(PrimitiveType::CompilerBoolean)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BroadType {
+    Unknown,
+    Num,
+    Str,
+    Function,
+    TagUnion,
+    List,
+    Record,
+}
+
+fn compute_broad_type(constraint_vec: &Vec<Constraint>) -> Result<BroadType, ()> {
+    let mut broad_type = BroadType::Unknown;
+    for constraint in constraint_vec {
+        let predicted_type = match constraint {
+            Constraint::EqualToPrimitive(primitive) => match primitive {
+                PrimitiveType::CompilerBoolean => return Err(()),
+                PrimitiveType::Num => BroadType::Num,
+                PrimitiveType::Str => BroadType::Str,
+            },
+            Constraint::ListOfType(_) => BroadType::List,
+            Constraint::HasTag(_) | Constraint::TagAtMost(_) => BroadType::TagUnion,
+            Constraint::HasField(_) | Constraint::HasMethod(_) => BroadType::Record,
+            Constraint::HasReturnType(_) | Constraint::HasArgumentTypes(_) => BroadType::Function,
+        };
+        match broad_type {
+            BroadType::Unknown => {
+                broad_type = predicted_type;
+            }
+            _ => {
+                if predicted_type != broad_type {
+                    return Err(());
+                }
+            }
+        };
+    }
+    Ok(broad_type)
+}
+
+fn resolve_generic_type(
+    simplified_schema: &TypeSchema,
+    substitutions: &mut TypeSchemaSubstitutions,
+    type_id: GenericTypeId,
+) -> Result<ConcreteType, ()> {
+    let constraint_vec = match simplified_schema
+        .constraints
+        .get(&substitutions.get_canonical_id(type_id))
+    {
+        Some(x) => x,
+        None => return Err(()),
+    };
+    let broad_type = compute_broad_type(constraint_vec)?;
+    match broad_type {
+        // If a type does not have constraints, then it does not matter what the type is.
+        BroadType::Unknown => Ok(ConcreteType::Primitive(PrimitiveType::CompilerBoolean)),
+        BroadType::Num => Ok(ConcreteType::Primitive(PrimitiveType::Num)),
+        BroadType::Str => Ok(ConcreteType::Primitive(PrimitiveType::Str)),
+        BroadType::Function => Ok(ConcreteType::Function(Box::new(ConcreteFunctionType {
+            argument_types: vec![],
+            return_type: None,
+        }))),
+        BroadType::TagUnion => Ok(resolve_tag_union_type(constraint_vec)),
+        BroadType::List => Ok(ConcreteType::List(Box::new(ConcreteListType {
+            element_type: ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
+        }))),
+        BroadType::Record => Ok(ConcreteType::Record(Box::new(ConcreteRecordType {
+            field_types: HashMap::new(),
+        }))),
+    }
+}
+
+fn resolve_expression<'a>(
+    simplified_schema: &TypeSchema,
+    substitutions: &mut TypeSchemaSubstitutions,
+    expression: GenericExpression<'a>,
+) -> Result<ConcreteExpression, ()> {
+    match expression {
+        GenericExpression::BinaryOperator(generic_binary_operator) => Ok(
+            ConcreteExpression::BinaryOperator(Box::new(ConcreteBinaryOperatorExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_binary_operator.expression_type.type_id,
+                )?,
+                symbol: generic_binary_operator.symbol,
+                left_child: resolve_expression(
+                    simplified_schema,
+                    substitutions,
+                    generic_binary_operator.left_child,
+                )?,
+                right_child: resolve_expression(
+                    simplified_schema,
+                    substitutions,
+                    generic_binary_operator.right_child,
+                )?,
+            })),
+        ),
+        GenericExpression::Block(generic_block) => Ok(ConcreteExpression::Block(Box::new(
+            ConcreteBlockExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_block.expression_type.type_id,
+                )?,
+                contents: vec![],
+            },
+        ))),
+        GenericExpression::Boolean(generic_boolean) => Ok(ConcreteExpression::Boolean(Box::new(
+            ConcreteBooleanExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_boolean.expression_type.type_id,
+                )?,
+                value: generic_boolean.value,
+            },
+        ))),
+        GenericExpression::Declaration(generic_declaration) => Ok(ConcreteExpression::Declaration(
+            Box::new(ConcreteDeclarationExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_declaration.expression_type.type_id,
+                )?,
+                identifier: match resolve_expression(
+                    simplified_schema,
+                    substitutions,
+                    GenericExpression::Identifier(Box::new(generic_declaration.identifier)),
+                )? {
+                    ConcreteExpression::Identifier(x) => *x,
+                    _ => return Err(()),
+                },
+                value: resolve_expression(
+                    simplified_schema,
+                    substitutions,
+                    generic_declaration.value,
+                )?,
+            }),
+        )),
+        GenericExpression::Function(generic_function) => Ok(ConcreteExpression::Function(
+            Box::new(ConcreteFunctionExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_function.expression_type.type_id,
+                )?,
+                argument_names: vec![],
+                body: resolve_expression(simplified_schema, substitutions, generic_function.body)?,
+            }),
+        )),
+        GenericExpression::Identifier(generic_identifier) => Ok(ConcreteExpression::Identifier(
+            Box::new(ConcreteIdentifierExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_identifier.expression_type.type_id,
+                )?,
+                name: generic_identifier.name,
+                is_disregarded: generic_identifier.is_disregarded,
+            }),
+        )),
+        GenericExpression::Integer(generic_integer) => Ok(ConcreteExpression::Integer(Box::new(
+            ConcreteIntegerLiteralExpression {
+                expression_type: resolve_generic_type(
+                    simplified_schema,
+                    substitutions,
+                    generic_integer.expression_type.type_id,
+                )?,
+                value: generic_integer.value,
+            },
+        ))),
+        _ => unimplemented!(),
+    }
+}
+
+fn resolve_variable_declaration_types(
+    mut input: TopLevelDeclaration<GenericVariableDeclaration>,
+) -> Result<TopLevelDeclaration<ConcreteVariableDeclaration>, ()> {
+    let mut simplified_schema = input
+        .declaration
+        .substitutions
+        .apply_to_type_schema(input.declaration.schema);
+    Ok(TopLevelDeclaration {
+        declaration: ConcreteVariableDeclaration {
+            declaration_type: resolve_generic_type(
+                &mut simplified_schema,
+                &mut input.declaration.substitutions,
+                input.declaration.declaration.declaration_type.type_id,
+            )?,
+            identifier_name: input.declaration.declaration.identifier_name,
+            expression: resolve_expression(
+                &mut simplified_schema,
+                &mut input.declaration.substitutions,
+                input.declaration.declaration.expression,
+            )?,
+        },
+        is_exported: input.is_exported,
+    })
+}
+
+pub fn resolve_concrete_types(input: GenericDocument) -> Result<ConcreteDocument, ()> {
+    let variable_declarations: Result<
+        Vec<TopLevelDeclaration<TypedVariableDeclaration<ConcreteType>>>,
+        (),
+    > = input
+        .variable_declarations
+        .into_iter()
+        .map(resolve_variable_declaration_types)
+        .collect();
+    Ok(ConcreteDocument {
+        imports: input.imports,
+        type_declarations: vec![],
+        variable_declarations: variable_declarations?,
+        expressions: vec![],
+    })
+}

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeSchemaSubstitutions {
     /// Implement a disjoint set / union find data structure.
     /// The mapping from key `x` to value `y` signifies that `y` is the parent of `x`.

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -65,7 +65,7 @@ impl TypeSchemaSubstitutions {
     }
     fn apply_to_constraint(&mut self, constraint: Constraint) -> Constraint {
         match constraint {
-            Constraint::EqualToConcrete(x) => Constraint::EqualToConcrete(x),
+            Constraint::EqualToPrimitive(x) => Constraint::EqualToPrimitive(x),
             Constraint::ListOfType(element_type) => {
                 Constraint::ListOfType(self.get_canonical_id(element_type))
             }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -4,7 +4,7 @@ use crate::{
     TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
-    TypedUnaryOperatorExpression,
+    TypedUnaryOperatorExpression, TypedVariableDeclaration,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -23,6 +23,8 @@ pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
+
+pub type ConcreteVariableDeclaration = TypedVariableDeclaration<ConcreteType>;
 pub type ConcreteDocument<'a> = TypedDocument<'a, ConcreteType>;
 
 impl ConcreteExpression {


### PR DESCRIPTION
This PR adds `TODO(aaron)` comments to a number of missing features in the type-checker/type-resolver. These `TODO` annotations cover most, but possibly not all, of the missing features.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"resolve_concrete_types","parentHead":"26abfe659e51ed24d72e0987f4f2d5a815eddba1","parentPull":86,"trunk":"main"}
```
-->
