### PR TITLE
Correct integer tests

### DIFF
--- a/tests/js/valid/integers/unsigned.test.js
+++ b/tests/js/valid/integers/unsigned.test.js
@@ -3,11 +3,11 @@ import { one, onePlusTwo, two } from "@tests/js/valid/integers/unsigned.mjs"
 import { expect, it } from "bun:test"
 
 it("a literal with the value of 1 should be equal to 1", () => {
-    expect(one).toBe(1)
+    expect(one.valueOf()).toBe(1)
 })
 
 it("a literal with the value of 2 should be equal to 2", () => {
-    expect(two).toBe(2)
+    expect(two.valueOf()).toBe(2)
 })
 
 it("literal one plus literal two should equal three", () => {

--- a/tests/js/valid/integers/unsigned.test.js
+++ b/tests/js/valid/integers/unsigned.test.js
@@ -1,4 +1,4 @@
-import { one, two } from "@tests/js/valid/integers/unsigned.mjs"
+import { one, onePlusTwo, two } from "@tests/js/valid/integers/unsigned.mjs"
 
 import { expect, it } from "bun:test"
 
@@ -8,4 +8,8 @@ it("a literal with the value of 1 should be equal to 1", () => {
 
 it("a literal with the value of 2 should be equal to 2", () => {
     expect(two).toBe(2)
+})
+
+it("literal one plus literal two should equal three", () => {
+    expect(onePlusTwo.valueOf()).toBe(3)
 })


### PR DESCRIPTION
Because the Buri to JS compiler implements numbers sometimes as `number` and sometimes as `object`, we cannot rely on numeric quantities being equal to `number` primitives. `valueOf` always returns a `number` primitive for numeric types regardless of underlying implementation. Using this method in all numeric tests brings stability against future changes in implementation and consistency between tests.