### PR TITLE
Add e2e tests for the mathematical order of operations

### DIFF
--- a/tests/js/valid/integers/order-of-operations.buri
+++ b/tests/js/valid/integers/order-of-operations.buri
@@ -1,0 +1,101 @@
+@export
+twoTimesThreePlusOne = 2 * 3 + 1
+
+@export
+onePlusTwoTimesThree = 1 + 2 * 3
+
+@export
+twelveDividedThreePlusOne = 12 / 3 + 1
+
+@export
+onePlusTwelveDividedThree = 1 + 12 / 3
+
+@export
+eightyFiveModEightPlusTwo = 85 % 8 + 2
+
+@export
+twoPlusEightyFiveModEight = 2 + 85 % 8
+
+@export
+twoPowerThreePlusOne = 2 ** 3 + 1
+
+@export
+onePlusTwoPowerThree = 1 + 2 ** 3
+
+@export
+twoTimesThreeMinusOne = 2 * 3 - 1
+
+@export
+oneMinusTwoTimesThree = 1 - 2 * 3
+
+@export
+twelveDividedThreeMinusOne = 12 / 3 - 1
+
+@export
+oneMinusTwelveDividedThree = 1 - 12 / 3
+
+@export
+eightyFiveModEightMinusTwo = 85 % 8 - 2
+
+@export
+twoMinusEightyFiveModEight = 2 - 85 % 8
+
+@export
+twoPowerThreeMinusOne = 2 ** 3 - 1
+
+@export
+oneMinusTwoPowerThree = 1 - 2 ** 3
+
+@export
+lParenTwoTimesThreeRParenPlusOne = (2 * 3) + 1
+
+@export
+twoTimesLParenThreePlusOneRParen = 2 * (3 + 1)
+
+@export
+lParenTwelveDividedThreeRParenPlusOne = (12 / 3) + 1
+
+@export
+twelveDividedLParenThreePlusOneRParen = 12 / (3 + 1)
+
+@export
+lParenEightyFiveModEightRParenPlusTwo = (85 % 8) + 2
+
+@export
+eightyFiveModLParenEightPlusTwoRParen = 85 % (8 + 2)
+
+@export
+lParenTwoPowerThreeRParenPlusOne = (2 ** 3) + 1
+
+@export
+twoPowerLParenThreePlusOneRParen = 2 ** (3 + 1)
+
+@export
+lParenTwoTimesThreeRParenMinusOne = (2 * 3) - 1
+
+@export
+twoTimesLParenThreeMinusOneRParen = 2 * (3 - 1)
+
+@export
+lParenTwelveDividedThreeRParenMinusOne = (12 / 3) - 1
+
+@export
+twelveDividedLParenThreeMinusOneRParen = 12 / (3 - 1)
+
+@export
+lParenEightyFiveModEightRParenMinusTwo = (85 % 8) - 2
+
+@export
+eightyFiveModLParenEightMinusTwoRParen = 85 % (8 - 2)
+
+@export
+lParenTwoPowerThreeRParenMinusOne = (2 ** 3) - 1
+
+@export
+twoPowerLParenThreeMinusOneRParen = 2 ** (3 - 1)
+
+@export
+onePlusTwoTimesThreePowerSevenMinusFive = 1 + 2 * 3 ** 7 - 5
+
+@export
+onePlusLParenTwoTimesThreeRParenPowerLParenSevenMinusFiveRParen = 1 + (2 * 3) ** (7 - 5)

--- a/tests/js/valid/integers/order-of-operations.test.js
+++ b/tests/js/valid/integers/order-of-operations.test.js
@@ -1,0 +1,181 @@
+import {
+    eightyFiveModEightMinusTwo,
+    eightyFiveModEightPlusTwo,
+    eightyFiveModLParenEightMinusTwoRParen,
+    eightyFiveModLParenEightPlusTwoRParen,
+    lParenEightyFiveModEightRParenMinusTwo,
+    lParenEightyFiveModEightRParenPlusTwo,
+    lParenTwelveDividedThreeRParenMinusOne,
+    lParenTwelveDividedThreeRParenPlusOne,
+    lParenTwoPowerThreeRParenMinusOne,
+    lParenTwoPowerThreeRParenPlusOne,
+    lParenTwoTimesThreeRParenMinusOne,
+    lParenTwoTimesThreeRParenPlusOne,
+    oneMinusTwelveDividedThree,
+    oneMinusTwoPowerThree,
+    oneMinusTwoTimesThree,
+    onePlusLParenTwoTimesThreeRParenPowerLParenSevenMinusFiveRParen,
+    onePlusTwelveDividedThree,
+    onePlusTwoPowerThree,
+    onePlusTwoTimesThree,
+    onePlusTwoTimesThreePowerSevenMinusFive,
+    twelveDividedLParenThreeMinusOneRParen,
+    twelveDividedLParenThreePlusOneRParen,
+    twelveDividedThreeMinusOne,
+    twelveDividedThreePlusOne,
+    twoMinusEightyFiveModEight,
+    twoPlusEightyFiveModEight,
+    twoPowerLParenThreeMinusOneRParen,
+    twoPowerLParenThreePlusOneRParen,
+    twoPowerThreeMinusOne,
+    twoPowerThreePlusOne,
+    twoTimesLParenThreeMinusOneRParen,
+    twoTimesLParenThreePlusOneRParen,
+    twoTimesThreeMinusOne,
+    twoTimesThreePlusOne,
+} from "@tests/js/valid/integers/order-of-operations.mjs"
+import { describe, expect, it } from "bun:test"
+
+describe("raw expressions", () => {
+    it("2 * 3 + 1", () => {
+        expect(twoTimesThreePlusOne.valueOf()).toBe(7)
+    })
+
+    it("1 + 2 * 3", () => {
+        expect(onePlusTwoTimesThree.valueOf()).toBe(7)
+    })
+
+    it("12 / 3 + 1", () => {
+        expect(twelveDividedThreePlusOne.valueOf()).toBe(5)
+    })
+
+    it("1 + 12 / 3", () => {
+        expect(onePlusTwelveDividedThree.valueOf()).toBe(5)
+    })
+
+    it("85 % 8 + 2", () => {
+        expect(eightyFiveModEightPlusTwo.valueOf()).toBe(7)
+    })
+
+    it("2 + 85 % 8", () => {
+        expect(twoPlusEightyFiveModEight.valueOf()).toBe(7)
+    })
+
+    it("2 ** 3 + 1", () => {
+        expect(twoPowerThreePlusOne.valueOf()).toBe(9)
+    })
+
+    it("1 + 2 ** 3", () => {
+        expect(onePlusTwoPowerThree.valueOf()).toBe(9)
+    })
+
+    it("2 * 3 - 1", () => {
+        expect(twoTimesThreeMinusOne.valueOf()).toBe(5)
+    })
+
+    it("1 - 2 * 3", () => {
+        expect(oneMinusTwoTimesThree.valueOf()).toBe(-5)
+    })
+
+    it("12 / 3 - 1", () => {
+        expect(twelveDividedThreeMinusOne.valueOf()).toBe(3)
+    })
+
+    it("1 - 12 / 3", () => {
+        expect(oneMinusTwelveDividedThree.valueOf()).toBe(-3)
+    })
+
+    it("85 % 8 - 2", () => {
+        expect(eightyFiveModEightMinusTwo.valueOf()).toBe(3)
+    })
+
+    it("2 - 85 % 8", () => {
+        expect(twoMinusEightyFiveModEight.valueOf()).toBe(-3)
+    })
+
+    it("2 ** 3 - 1", () => {
+        expect(twoPowerThreeMinusOne.valueOf()).toBe(7)
+    })
+
+    it("1 - 2 ** 3", () => {
+        expect(oneMinusTwoPowerThree.valueOf()).toBe(-7)
+    })
+})
+
+describe("with parenthesis", () => {
+    it("(2 * 3) + 1", () => {
+        expect(lParenTwoTimesThreeRParenPlusOne.valueOf()).toBe(7)
+    })
+
+    it("2 * (3 + 1)", () => {
+        expect(twoTimesLParenThreePlusOneRParen.valueOf()).toBe(8)
+    })
+
+    it("(12 / 3) + 1", () => {
+        expect(lParenTwelveDividedThreeRParenPlusOne.valueOf()).toBe(5)
+    })
+
+    it("12 / (3 + 1)", () => {
+        expect(twelveDividedLParenThreePlusOneRParen.valueOf()).toBe(3)
+    })
+
+    it("(85 % 8) + 2", () => {
+        expect(lParenEightyFiveModEightRParenPlusTwo.valueOf()).toBe(7)
+    })
+
+    it("85 % (8 + 2)", () => {
+        expect(eightyFiveModLParenEightPlusTwoRParen.valueOf()).toBe(5)
+    })
+
+    it("(2 ** 3) + 1", () => {
+        expect(lParenTwoPowerThreeRParenPlusOne.valueOf()).toBe(9)
+    })
+
+    it("2 ** (3 + 1)", () => {
+        expect(twoPowerLParenThreePlusOneRParen.valueOf()).toBe(16)
+    })
+
+    it("(2 * 3) - 1", () => {
+        expect(lParenTwoTimesThreeRParenMinusOne.valueOf()).toBe(5)
+    })
+
+    it("2 * (3 - 1)", () => {
+        expect(twoTimesLParenThreeMinusOneRParen.valueOf()).toBe(4)
+    })
+
+    it("(12 / 3) - 1", () => {
+        expect(lParenTwelveDividedThreeRParenMinusOne.valueOf()).toBe(3)
+    })
+
+    it("12 / (3 - 1)", () => {
+        expect(twelveDividedLParenThreeMinusOneRParen.valueOf()).toBe(6)
+    })
+
+    it("(85 % 8) - 2", () => {
+        expect(lParenEightyFiveModEightRParenMinusTwo.valueOf()).toBe(3)
+    })
+
+    it("85 % (8 - 2)", () => {
+        expect(eightyFiveModLParenEightMinusTwoRParen.valueOf()).toBe(1)
+    })
+
+    it("(2 ** 3) - 1", () => {
+        expect(lParenTwoPowerThreeRParenMinusOne.valueOf()).toBe(7)
+    })
+
+    it("2 ** (3 - 1)", () => {
+        expect(twoPowerLParenThreeMinusOneRParen.valueOf()).toBe(4)
+    })
+})
+
+describe("complex expressions", () => {
+    it("1 + 2 * 3 ** 7 - 5", () => {
+        expect(onePlusTwoTimesThreePowerSevenMinusFive.valueOf()).toBe(4370)
+    })
+
+    it("1 + (2 * 3) ** (7 - 5)", () => {
+        expect(
+            onePlusLParenTwoTimesThreeRParenPowerLParenSevenMinusFiveRParen.valueOf()
+        ).toBe(37)
+    })
+})


### PR DESCRIPTION
There's still more order of operations testing (e.g., including the logical operators), but that should come later when we have a working version of the logical operators. Created B-225 to track that.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"resolve-unary-operator","parentHead":"9fe7c67afcf0b9489ee76cf011919e9b6c48f80e","parentPull":96,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"resolve-unary-operator","parentHead":"9fe7c67afcf0b9489ee76cf011919e9b6c48f80e","parentPull":96,"trunk":"main"}
```
-->
