### PR TITLE
Add commutative e2e tests

### DIFF
--- a/tests/js/valid/integers/commutativity.buri
+++ b/tests/js/valid/integers/commutativity.buri
@@ -1,0 +1,39 @@
+-- Commutative operators.
+
+@export
+onePlusTwo = 1 + 2
+
+@export
+twoPlusOne = 2 + 1
+
+@export
+oneTimesTwo = 1 * 2
+
+@export
+twoTimesOne = 2 * 1
+
+-- Non-commutative operators.
+
+@export
+oneMinusTwo = 1 - 2
+
+@export
+twoMinusOne = 2 - 1
+
+@export
+sixDivideThree = 6 / 3
+
+@export
+threeDivideSix = 3 / 6
+
+@export
+fourModSix = 4 % 6
+
+@export
+sixModFour = 6 % 4
+
+@export
+twoPowerThree = 2 ** 3
+
+@export
+threePowerTwo = 3 ** 2

--- a/tests/js/valid/integers/commutativity.test.js
+++ b/tests/js/valid/integers/commutativity.test.js
@@ -1,0 +1,55 @@
+import {
+    fourModSix,
+    oneMinusTwo,
+    onePlusTwo,
+    oneTimesTwo,
+    sixDivideThree,
+    sixModFour,
+    threeDivideSix,
+    threePowerTwo,
+    twoMinusOne,
+    twoPlusOne,
+    twoPowerThree,
+    twoTimesOne,
+} from "@tests/js/valid/integers/commutativity.mjs"
+import { describe, expect, it } from "bun:test"
+
+describe("commutative operators", () => {
+    describe("addition", () => {
+        it("1 + 2 == 2 + 1", () => {
+            expect(onePlusTwo.valueOf()).toBe(twoPlusOne.valueOf())
+        })
+    })
+
+    describe("multiplication", () => {
+        it("1 * 2 == 2 * 1", () => {
+            expect(oneTimesTwo.valueOf()).toBe(twoTimesOne.valueOf())
+        })
+    })
+})
+
+describe("non-commutative operators", () => {
+    describe("subtraction", () => {
+        it("1 - 2 != 2 - 1", () => {
+            expect(oneMinusTwo.valueOf()).not.toBe(twoMinusOne.valueOf())
+        })
+    })
+
+    describe("division", () => {
+        it("6 / 3 != 3 / 6", () => {
+            expect(sixDivideThree.valueOf()).not.toBe(threeDivideSix.valueOf())
+        })
+    })
+
+    describe("modulo", () => {
+        it("4 % 6 != 6 % 4", () => {
+            expect(fourModSix.valueOf()).not.toBe(sixModFour.valueOf())
+        })
+    })
+
+    describe("power", () => {
+        it("2 ** 3 != 3 ** 2", () => {
+            expect(twoPowerThree.valueOf()).not.toBe(threePowerTwo.valueOf())
+        })
+    })
+})


### PR DESCRIPTION
Figured we should probably test everything in the e2e tests, including things like commutativity that we usually take for granted. Otherwise we couldn't have the confidence even basic math works correctly.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"order-of-operations-tests","parentHead":"6c1dd3ac25b2c70f32c9f53e3f116286d40dce44","parentPull":97,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"order-of-operations-tests","parentHead":"6c1dd3ac25b2c70f32c9f53e3f116286d40dce44","parentPull":97,"trunk":"main"}
```
-->
