### PR TITLE
Add e2e tests for associativity

### DIFF
--- a/tests/js/valid/integers/associativity.buri
+++ b/tests/js/valid/integers/associativity.buri
@@ -1,0 +1,57 @@
+-- Associative operators.
+
+@export
+onePlusTwoPlusThree = 1 + 2 + 3
+
+@export
+onePlusLParenTwoPlusThreeRParen = 1 + (2 + 3)
+
+@export
+lParenOnePlusTwoRParenPlusThree = (1 + 2) + 3
+
+@export
+oneTimesTwoTimesThree = 1 * 2 * 3
+
+@export
+oneTimesLParenTwoTimesThreeRParen = 1 * (2 * 3)
+
+@export
+lParenOneTimesTwoRParenTimesThree = (1 * 2) * 3
+
+@export
+twoPowerThreePowerTwo = 2 ** 3 ** 2
+
+@export
+twoPowerLParenThreePowerTwoRParen = 2 ** (3 ** 2)
+
+@export
+lParenTwoPowerThreeRParenPowerTwo = (2 ** 3) ** 2
+
+-- Non-associative operators.
+
+@export
+tenMinusFiveMinusTwo = 10 - 5 - 2
+
+@export
+tenMinusLParenFiveMinusTwoRParen = 10 - (5 - 2)
+
+@export
+lParenTenMinusFiveRParenMinusTwo = (10 - 5) - 2
+
+@export
+eightDivideThreeDivideTwo = 8 / 3 / 2
+
+@export
+eightDivideLParenThreeDivideTwoRParen = 8 / (3 / 2)
+
+@export
+lParenEightDivideThreeRParenDivideTwo = (8 / 3) / 2
+
+@export
+eightModFiveModTwo = 8 % 5 % 2
+
+@export
+eightModLParenFiveModTwoRParen = 8 % (5 % 2)
+
+@export
+lParenEightModFiveRParenModTwo = (8 % 5) % 2

--- a/tests/js/valid/integers/associativity.test.js
+++ b/tests/js/valid/integers/associativity.test.js
@@ -1,0 +1,104 @@
+import {
+    eightDivideLParenThreeDivideTwoRParen,
+    eightDivideThreeDivideTwo,
+    eightModFiveModTwo,
+    eightModLParenFiveModTwoRParen,
+    lParenEightDivideThreeRParenDivideTwo,
+    lParenEightModFiveRParenModTwo,
+    lParenOnePlusTwoRParenPlusThree,
+    lParenOneTimesTwoRParenTimesThree,
+    lParenTenMinusFiveRParenMinusTwo,
+    lParenTwoPowerThreeRParenPowerTwo,
+    onePlusLParenTwoPlusThreeRParen,
+    onePlusTwoPlusThree,
+    oneTimesLParenTwoTimesThreeRParen,
+    oneTimesTwoTimesThree,
+    tenMinusFiveMinusTwo,
+    tenMinusLParenFiveMinusTwoRParen,
+    twoPowerLParenThreePowerTwoRParen,
+} from "@tests/js/valid/integers/associativity.mjs"
+import { describe, expect, it } from "bun:test"
+
+describe("associative operators", () => {
+    describe("addition", () => {
+        it("1 + (2 + 3) == (1 + 2) + 3", () => {
+            expect(onePlusLParenTwoPlusThreeRParen.valueOf()).toBe(
+                lParenOnePlusTwoRParenPlusThree.valueOf()
+            )
+        })
+
+        it("addition is left associative by default: 1 + 2 + 3 == (1 + 2) + 3", () => {
+            expect(onePlusTwoPlusThree.valueOf()).toBe(
+                lParenOnePlusTwoRParenPlusThree.valueOf()
+            )
+        })
+    })
+
+    describe("multiplication", () => {
+        it("1 * (2 * 3) == (1 * 2) * 3", () => {
+            expect(oneTimesLParenTwoTimesThreeRParen.valueOf()).toBe(
+                lParenOneTimesTwoRParenTimesThree.valueOf()
+            )
+        })
+
+        it("multiplication is left associative by default: 1 * 2 * 3 == (1 * 2) * 3", () => {
+            expect(oneTimesTwoTimesThree.valueOf()).toBe(
+                lParenOneTimesTwoRParenTimesThree.valueOf()
+            )
+        })
+    })
+})
+
+describe("non-associative operators", () => {
+    describe("subtraction", () => {
+        it("10 - (5 - 2) != (10 - 5) - 2", () => {
+            expect(tenMinusLParenFiveMinusTwoRParen.valueOf()).not.toBe(
+                lParenTenMinusFiveRParenMinusTwo.valueOf()
+            )
+        })
+
+        it("subtraction is left associative by default: 10 - 5 - 2 == (10 - 5) - 2", () => {
+            expect(tenMinusFiveMinusTwo.valueOf()).toBe(
+                lParenTenMinusFiveRParenMinusTwo.valueOf()
+            )
+        })
+    })
+
+    describe("division", () => {
+        it("8 / (3 / 2) != (8 / 3) / 2", () => {
+            expect(eightDivideLParenThreeDivideTwoRParen.valueOf()).not.toBe(
+                lParenEightDivideThreeRParenDivideTwo.valueOf()
+            )
+        })
+
+        it("division is left associative by default: 8 / 3 / 2 == (8 / 3) / 2", () => {
+            expect(eightDivideThreeDivideTwo.valueOf()).toBe(
+                lParenEightDivideThreeRParenDivideTwo.valueOf()
+            )
+        })
+    })
+
+    describe("modulo", () => {
+        it("8 % (5 % 2) != (8 % 5) % 2", () => {
+            expect(eightModLParenFiveModTwoRParen.valueOf()).not.toBe(
+                lParenEightModFiveRParenModTwo.valueOf()
+            )
+        })
+
+        it("modulo is left associative by default: 8 % 5 % 2 == (8 % 5) % 2", () => {
+            expect(eightModFiveModTwo.valueOf()).toBe(
+                lParenEightModFiveRParenModTwo.valueOf()
+            )
+        })
+    })
+
+    describe("power", () => {
+        it("2 ** (3 ** 2) != (2 ** 3) ** 2", () => {
+            expect(twoPowerLParenThreePowerTwoRParen.valueOf()).not.toBe(
+                lParenTwoPowerThreeRParenPowerTwo.valueOf()
+            )
+        })
+
+        // TODO(B-226): Write a test that shows that power is _right_ associative by default.
+    })
+})


### PR DESCRIPTION
Good thing I'm writing tests for the basic things because I found a bug: exponentiation should be right associative. Filed that as B-226 to keep track of it.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"commutative-tests","parentHead":"ce371e0c9bbdb531a4dcd564ff152a34e7c04024","parentPull":98,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"commutative-tests","parentHead":"ce371e0c9bbdb531a4dcd564ff152a34e7c04024","parentPull":98,"trunk":"main"}
```
-->
