### PR TITLE
Add parenthesis around unary operators when they're the left side of a binary operator

### DIFF
--- a/rust/js_backend/src/expression/binary_operator.rs
+++ b/rust/js_backend/src/expression/binary_operator.rs
@@ -57,10 +57,11 @@ fn get_format(operator: &BinaryOperatorSymbol) -> OperatorFormat {
 }
 
 fn maybe_parenthesize_left(string: &str, expression: &ConcreteExpression) -> String {
-    if let ConcreteExpression::Integer(_) = expression {
-        format!("({string})")
-    } else {
-        super::print_expression(expression)
+    match expression {
+        ConcreteExpression::Integer(_) | ConcreteExpression::UnaryOperator(_) => {
+            format!("({string})")
+        }
+        _ => string.to_string(),
     }
 }
 
@@ -102,6 +103,19 @@ mod test {
     }
 
     #[test]
+    fn addition_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Add,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).add(2)");
+    }
+
+    #[test]
     fn addition_without_number_literals_do_not_have_parenthesis() {
         let expression = ConcreteBinaryOperatorExpression {
             expression_type: ConcreteType::default_binary_operator_for_test(),
@@ -135,6 +149,19 @@ mod test {
     }
 
     #[test]
+    fn subtraction_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Subtract,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).subtract(2)");
+    }
+
+    #[test]
     fn subtraction_without_number_literals_do_not_have_parenthesis() {
         let expression = ConcreteBinaryOperatorExpression {
             expression_type: ConcreteType::default_binary_operator_for_test(),
@@ -154,6 +181,19 @@ mod test {
             right_child: ConcreteExpression::integer_for_test(2),
         };
         assert_eq!(print_binary_operator(&expression), "(1).multiply(2)");
+    }
+
+    #[test]
+    fn multiplication_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Multiply,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).multiply(2)");
     }
 
     #[test]
@@ -179,6 +219,19 @@ mod test {
     }
 
     #[test]
+    fn division_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Divide,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).divide(2)");
+    }
+
+    #[test]
     fn division_without_number_literals_do_not_have_parenthesis() {
         let expression = ConcreteBinaryOperatorExpression {
             expression_type: ConcreteType::default_binary_operator_for_test(),
@@ -201,6 +254,19 @@ mod test {
     }
 
     #[test]
+    fn power_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Power,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).power(2)");
+    }
+
+    #[test]
     fn power_without_number_literals_do_not_have_parenthesis() {
         let expression = ConcreteBinaryOperatorExpression {
             expression_type: ConcreteType::default_binary_operator_for_test(),
@@ -220,6 +286,19 @@ mod test {
             right_child: ConcreteExpression::integer_for_test(2),
         };
         assert_eq!(print_binary_operator(&expression), "(1).modulo(2)");
+    }
+
+    #[test]
+    fn modulus_with_unary_operator_has_parenthesis() {
+        let expression = ConcreteBinaryOperatorExpression {
+            expression_type: ConcreteType::default_binary_operator_for_test(),
+            symbol: BinaryOperatorSymbol::Modulus,
+            left_child: ConcreteExpression::negative_unary_operator_for_test(
+                ConcreteExpression::integer_for_test(1),
+            ),
+            right_child: ConcreteExpression::integer_for_test(2),
+        };
+        assert_eq!(print_binary_operator(&expression), "(-1).modulo(2)");
     }
 
     #[test]

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -65,4 +65,13 @@ impl ConcreteExpression {
             contents: expressions,
         }))
     }
+
+    #[must_use]
+    pub fn negative_unary_operator_for_test(child: Self) -> Self {
+        Self::UnaryOperator(Box::new(ConcreteUnaryOperatorExpression {
+            expression_type: ConcreteType::default_integer_for_test(),
+            symbol: ast::UnaryOperatorSymbol::Negative,
+            child,
+        }))
+    }
 }


### PR DESCRIPTION
In JS, you cannot call a method on a number literal. That includes negative numbers.

```js
-8.add(2) // cannot call `.add` on number literal `-8`
```

The solution to this, like with non-negative numbers, is to wrap the negative number in parenthesis.

```js
(-8).add(2)
```

Relevant e2e tests coming in the next PR.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"associative-tests","parentHead":"3adf4d8ab6b7efbbf18f5994b9832393974530ce","parentPull":99,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"associative-tests","parentHead":"3adf4d8ab6b7efbbf18f5994b9832393974530ce","parentPull":99,"trunk":"main"}
```
-->
