### PR TITLE
Remove unnecessary include in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,4 @@
             "@*": ["./*", "./.buri/dist/*"]
         }
     },
-    "include": ["**/*.js", "**/*.ts", "tests/js/valid/integers/unsigned.mjs"]
-}
+    "include": ["**/*.js", "**/*.ts"]


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"division-e2e","parentHead":"35102c71107d61de7df841dc0559fa95df8a88b1","parentPull":101,"trunk":"main"}
```
-->
