### PR TITLE
Add variable type checking

### DIFF
--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -3,6 +3,7 @@ mod constraints;
 mod generic_nodes;
 mod parsed_expression_to_generic_expression;
 mod resolve_concrete_types;
+mod scope;
 mod type_schema;
 mod type_schema_substitutions;
 

--- a/rust/type_checker/src/scope.rs
+++ b/rust/type_checker/src/scope.rs
@@ -1,0 +1,40 @@
+use crate::GenericTypeId;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Scope {
+    pub parent_scope: Option<Box<Scope>>,
+    pub identifiers: HashMap<String, GenericTypeId>,
+}
+
+impl Scope {
+    pub fn new_head() -> Box<Self> {
+        Box::new(Self {
+            parent_scope: None,
+            identifiers: HashMap::new(),
+        })
+    }
+    pub fn new_sub_scope(input: Box<Self>) -> Box<Self> {
+        Box::new(Self {
+            parent_scope: Some(input),
+            identifiers: HashMap::new(),
+        })
+    }
+    pub fn get_variable_declaration_type(&self, identifier_name: &str) -> Option<GenericTypeId> {
+        self.identifiers.get(identifier_name).map_or_else(
+            || {
+                self.parent_scope
+                    .as_ref()
+                    .and_then(|parent| parent.get_variable_declaration_type(identifier_name))
+            },
+            |x| Some(*x),
+        )
+    }
+    pub fn add_variable_declaration(
+        &mut self,
+        identifier_name: String,
+        identifier_type: GenericTypeId,
+    ) {
+        self.identifiers.insert(identifier_name, identifier_type);
+    }
+}

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -139,6 +139,7 @@ impl TypeSchemaSubstitutions {
             next_id: input.next_id,
             constraints: self.apply_to_constraints_map(input.constraints),
             imports: self.apply_to_imports_map(input.imports),
+            scope: None,
         }
     }
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
