### PR TITLE
Test variable declaration parsing where the right hand side is an identifier.

### DIFF
--- a/rust/parser/src/variable_declaration.rs
+++ b/rust/parser/src/variable_declaration.rs
@@ -183,4 +183,13 @@ mod test {
         let result = variable_declaration(input);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn right_hand_side_can_be_identifier() {
+        let input = "foo = bar";
+        let input = ParserInput::new(input);
+        let result = variable_declaration(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
 }


### PR DESCRIPTION
Relates to [B-227](https://linear.app/cambiata/issue/B-227). The test in this PR demonstrates that the B-227 bug is not present in the variable declaration parser.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
