### PR TITLE
Reverse key and value roles in TypeSchema imports

### DIFF
--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -316,10 +316,10 @@ fn translate_identifier<'a>(
             if let Some(typ) = scope.get_variable_declaration_type(&node.value.name) {
                 typ
             } else {
-                schema.register_import(&node.value.name)
+                schema.register_import(node.value.name.clone())
             }
         }
-        None => schema.register_import(&node.value.name),
+        None => schema.register_import(node.value.name.clone()),
     };
     substitutions.insert_new_id(type_id);
     GenericIdentifierExpression {

--- a/rust/type_checker/src/resolve_concrete_types.rs
+++ b/rust/type_checker/src/resolve_concrete_types.rs
@@ -425,6 +425,18 @@ fn resolve_variable_declaration_types(
 }
 
 pub fn resolve_concrete_types(input: GenericDocument) -> Result<ConcreteDocument, ()> {
+    let mut constraints: HashMap<String, HashMap<GenericTypeId, Vec<Constraint>>> = HashMap::new();
+    for declaration in &input.variable_declarations {
+        match constraints.get(&declaration.declaration.declaration.identifier_name) {
+            Some(_) => return Err(()),
+            None => {
+                constraints.insert(
+                    declaration.declaration.declaration.identifier_name.clone(),
+                    declaration.declaration.schema.constraints.clone(),
+                );
+            }
+        }
+    }
     let variable_declarations: Result<
         Vec<TopLevelDeclaration<TypedVariableDeclaration<ConcreteType>>>,
         (),

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, mem::swap};
 pub struct TypeSchema {
     pub next_id: GenericTypeId,
     pub constraints: HashMap<GenericTypeId, Vec<Constraint>>,
-    pub imports: HashMap<String, GenericTypeId>,
+    pub imports: HashMap<GenericTypeId, String>,
     pub scope: Option<Box<Scope>>,
 }
 
@@ -44,14 +44,10 @@ impl TypeSchema {
         constraint_count
     }
     /// Return the generic type id for an imported identifier, creating the id if necessary.
-    pub fn register_import(&mut self, identifier_name: &str) -> GenericTypeId {
-        if let Some(x) = self.imports.get(identifier_name) {
-            *x
-        } else {
-            let new_id = self.make_id();
-            self.imports.insert(identifier_name.to_owned(), new_id);
-            new_id
-        }
+    pub fn register_import(&mut self, identifier_name: String) -> GenericTypeId {
+        let new_id = self.make_id();
+        self.imports.insert(new_id, identifier_name);
+        new_id
     }
     /// Replaces the scope with a new value, returning the old value.
     fn update_scope(&mut self, mut value: Option<Box<Scope>>) -> Option<Box<Scope>> {

--- a/rust/type_checker/src/type_schema_substitutions.rs
+++ b/rust/type_checker/src/type_schema_substitutions.rs
@@ -126,11 +126,11 @@ impl TypeSchemaSubstitutions {
     }
     fn apply_to_imports_map(
         &mut self,
-        input: HashMap<String, GenericTypeId>,
-    ) -> HashMap<String, GenericTypeId> {
+        input: HashMap<GenericTypeId, String>,
+    ) -> HashMap<GenericTypeId, String> {
         let mut output = HashMap::new();
         for (key, value) in input {
-            output.insert(key, self.get_canonical_id(value));
+            output.insert(self.get_canonical_id(key), value);
         }
         output
     }
@@ -408,31 +408,22 @@ mod test {
     fn apply_to_type_schema_replaces_all_instances_of_a_given_id_in_import_values() {
         let mut substitutions = TypeSchemaSubstitutions::new();
         let mut schema = TypeSchema::new();
-        let type_a = schema.make_id();
-        let type_b = schema.make_id();
-        let type_c = schema.make_id();
+        let type_a = schema.register_import("apple".to_owned());
+        let type_b = schema.register_import("banana".to_owned());
+        let type_c = schema.register_import("carrot".to_owned());
         substitutions.insert_new_id(type_a);
         substitutions.insert_new_id(type_b);
         substitutions.insert_new_id(type_c);
-        schema.imports.insert("apple".to_owned(), type_a);
-        schema.imports.insert("banana".to_owned(), type_b);
-        schema.imports.insert("carrot".to_owned(), type_c);
         substitutions.set_types_equal(type_a, type_b);
         assert_eq!(
-            substitutions.get_canonical_id(*schema.imports.get("apple").unwrap()),
-            substitutions.get_canonical_id(type_a)
-        );
-        assert_eq!(
-            substitutions.get_canonical_id(*schema.imports.get("apple").unwrap()),
-            substitutions.get_canonical_id(type_b)
-        );
-        assert_eq!(
-            substitutions.get_canonical_id(*schema.imports.get("banana").unwrap()),
-            substitutions.get_canonical_id(type_a)
-        );
-        assert_eq!(
-            substitutions.get_canonical_id(*schema.imports.get("banana").unwrap()),
-            substitutions.get_canonical_id(type_b)
+            schema
+                .imports
+                .get(&substitutions.get_canonical_id(type_a))
+                .unwrap(),
+            schema
+                .imports
+                .get(&substitutions.get_canonical_id(type_b))
+                .unwrap()
         );
     }
 
@@ -440,19 +431,19 @@ mod test {
     fn apply_to_type_schema_does_not_replace_non_substituted_ids_in_import_values() {
         let mut substitutions = TypeSchemaSubstitutions::new();
         let mut schema = TypeSchema::new();
-        let type_a = schema.make_id();
-        let type_b = schema.make_id();
-        let type_c = schema.make_id();
+        let type_a = schema.register_import("apple".to_owned());
+        let type_b = schema.register_import("banana".to_owned());
+        let type_c = schema.register_import("carrot".to_owned());
         substitutions.insert_new_id(type_a);
         substitutions.insert_new_id(type_b);
         substitutions.insert_new_id(type_c);
-        schema.imports.insert("apple".to_owned(), type_a);
-        schema.imports.insert("banana".to_owned(), type_b);
-        schema.imports.insert("carrot".to_owned(), type_c);
         substitutions.set_types_equal(type_a, type_b);
         assert_eq!(
-            substitutions.get_canonical_id(*schema.imports.get("carrot").unwrap()),
-            substitutions.get_canonical_id(type_c)
+            schema
+                .imports
+                .get(&substitutions.get_canonical_id(type_c))
+                .unwrap(),
+            "carrot"
         );
     }
 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
