### PR TITLE
Make exponentiation right associative (Fixes B-226)

### DIFF
--- a/tests/js/valid/integers/associativity.buri
+++ b/tests/js/valid/integers/associativity.buri
@@ -18,15 +18,6 @@ oneTimesLParenTwoTimesThreeRParen = 1 * (2 * 3)
 @export
 lParenOneTimesTwoRParenTimesThree = (1 * 2) * 3
 
-@export
-twoPowerThreePowerTwo = 2 ** 3 ** 2
-
-@export
-twoPowerLParenThreePowerTwoRParen = 2 ** (3 ** 2)
-
-@export
-lParenTwoPowerThreeRParenPowerTwo = (2 ** 3) ** 2
-
 -- Non-associative operators.
 
 @export
@@ -55,3 +46,12 @@ eightModLParenFiveModTwoRParen = 8 % (5 % 2)
 
 @export
 lParenEightModFiveRParenModTwo = (8 % 5) % 2
+
+@export
+twoPowerThreePowerTwo = 2 ** 3 ** 2
+
+@export
+twoPowerLParenThreePowerTwoRParen = 2 ** (3 ** 2)
+
+@export
+lParenTwoPowerThreeRParenPowerTwo = (2 ** 3) ** 2

--- a/tests/js/valid/integers/associativity.test.js
+++ b/tests/js/valid/integers/associativity.test.js
@@ -16,6 +16,7 @@ import {
     tenMinusFiveMinusTwo,
     tenMinusLParenFiveMinusTwoRParen,
     twoPowerLParenThreePowerTwoRParen,
+    twoPowerThreePowerTwo,
 } from "@tests/js/valid/integers/associativity.mjs"
 import { describe, expect, it } from "bun:test"
 
@@ -99,6 +100,10 @@ describe("non-associative operators", () => {
             )
         })
 
-        // TODO(B-226): Write a test that shows that power is _right_ associative by default.
+        it("power is right associative by default: 2 ** 3 ** 2 == 2 ** (3 ** 2)", () => {
+            expect(twoPowerThreePowerTwo.valueOf()).toBe(
+                twoPowerLParenThreePowerTwoRParen.valueOf()
+            )
+        })
     })
 })


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
