### PR TITLE
Add variable declarations as expressions

### DIFF
--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -60,7 +60,7 @@ pub struct TopLevelDeclaration<T> {
 pub struct DocumentValue<'a> {
     pub imports: Vec<ImportNode<'a>>,
     pub type_declarations: Vec<TopLevelDeclaration<TypeDeclarationNode<'a>>>,
-    pub variable_declarations: Vec<TopLevelDeclaration<VariableDeclarationNode<'a>>>,
+    pub variable_declarations: Vec<TopLevelDeclaration<DeclarationNode<'a>>>,
     pub expressions: Vec<Expression<'a>>,
 }
 
@@ -140,7 +140,7 @@ pub struct TagTypeValue<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeDeclarationValue<'a> {
     pub identifier: TypeIdentifierNode<'a>,
-    pub type_expression: TypeExpression<'a>,
+    pub type_expression: Box<TypeExpression<'a>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,10 +167,10 @@ pub struct UnaryOperatorValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VariableDeclarationValue<'a> {
+pub struct DeclarationValue<'a> {
     pub identifier: IdentifierNode<'a>,
     pub type_expression: Option<TypeExpression<'a>>,
-    pub expression: Expression<'a>,
+    pub expression: Box<Expression<'a>>,
 }
 
 pub type BinaryOperatorNode<'a> = ParsedNode<'a, BinaryOperatorValue<'a>>;
@@ -199,12 +199,13 @@ pub type TagTypeNode<'a> = ParsedNode<'a, TagTypeValue<'a>>;
 pub type TypeIdentifierNode<'a> = ParsedNode<'a, String>;
 pub type TypeDeclarationNode<'a> = ParsedNode<'a, TypeDeclarationValue<'a>>;
 pub type UnaryOperatorNode<'a> = ParsedNode<'a, UnaryOperatorValue<'a>>;
-pub type VariableDeclarationNode<'a> = ParsedNode<'a, VariableDeclarationValue<'a>>;
+pub type DeclarationNode<'a> = ParsedNode<'a, DeclarationValue<'a>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expression<'a> {
     BinaryOperator(BinaryOperatorNode<'a>),
     Block(BlockNode<'a>),
+    Declaration(DeclarationNode<'a>),
     Function(FunctionNode<'a>),
     FunctionApplicationArguments(FunctionApplicationArgumentsNode<'a>),
     Identifier(IdentifierNode<'a>),
@@ -215,6 +216,7 @@ pub enum Expression<'a> {
     RecordAssignment(RecordAssignmentNode<'a>),
     StringLiteral(StringLiteralNode<'a>),
     Tag(TagNode<'a>),
+    TypeDeclaration(TypeDeclarationNode<'a>),
     UnaryOperator(UnaryOperatorNode<'a>),
 }
 

--- a/rust/js_backend/src/expression/declaration.rs
+++ b/rust/js_backend/src/expression/declaration.rs
@@ -16,6 +16,7 @@ mod test {
     #[test]
     fn declare_an_integer() {
         let declaration = ConcreteDeclarationExpression {
+            declaration_type: ConcreteType::default_integer_for_test(),
             expression_type: ConcreteType::default_integer_for_test(),
             identifier: ConcreteExpression::raw_identifier_for_test("foo"),
             value: ConcreteExpression::integer_for_test(42),
@@ -26,6 +27,7 @@ mod test {
     #[test]
     fn declare_a_string() {
         let declaration = ConcreteDeclarationExpression {
+            declaration_type: ConcreteType::default_integer_for_test(),
             expression_type: ConcreteType::default_string_for_test(),
             identifier: ConcreteExpression::raw_identifier_for_test("hello"),
             value: ConcreteExpression::string_for_test("world"),

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 use typed_ast::ConcreteExpression;
 
-pub fn print_expression(expression: &ConcreteExpression) -> String {
+pub use declaration::print_declaration;
+
+fn print_expression(expression: &ConcreteExpression) -> String {
     match expression {
         ConcreteExpression::Identifier(identifier) => print_identifier(identifier),
         ConcreteExpression::Integer(integer) => print_integer_literal(integer),
@@ -43,6 +45,9 @@ pub fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::Declaration(declaration) => declaration::print_declaration(declaration),
         ConcreteExpression::FunctionArguments(arguments) => {
             function_arguments::print_function_arguments(arguments)
+        }
+        ConcreteExpression::TypeDeclaration(_) | ConcreteExpression::TypeIdentifier(_) => {
+            String::new()
         }
     }
 }
@@ -186,6 +191,7 @@ mod test {
     fn print_declaration() {
         let declaration =
             ConcreteExpression::Declaration(Box::new(ConcreteDeclarationExpression {
+                declaration_type: ConcreteType::default_integer_for_test(),
                 expression_type: ConcreteType::default_integer_for_test(),
                 identifier: ConcreteExpression::raw_identifier_for_test("foo"),
                 value: ConcreteExpression::integer_for_test(42),

--- a/rust/js_backend/src/lib.rs
+++ b/rust/js_backend/src/lib.rs
@@ -1,4 +1,4 @@
-use expression::print_expression;
+use expression::print_declaration;
 use imports::print_imports;
 use typed_ast::{ConcreteType, TypedDocument};
 
@@ -16,12 +16,7 @@ pub fn print_js_document(document: &TypedDocument<ConcreteType>) -> String {
         if declaration.is_exported {
             result.push_str("export ");
         }
-        result.push_str("const ");
-        // TODO(B-218): Clean this up to use the print_declaration method instead
-        // manually rewriting that code here.
-        result.push_str(&declaration.declaration.identifier_name);
-        result.push('=');
-        result.push_str(&print_expression(&declaration.declaration.expression));
+        result.push_str(&print_declaration(&declaration.declaration));
     }
     result
 }

--- a/rust/parser/src/basic_expression.rs
+++ b/rust/parser/src/basic_expression.rs
@@ -1,7 +1,8 @@
 use crate::{
     function::function, identifier::identifier, integer::integer, list::list,
     parentheses::parentheses, record::record, record_assignment::record_assignment,
-    string_literal::string_literal, tag::tag, unary_operator::unary_operator_expression,
+    string_literal::string_literal, tag::tag, type_declaration::type_declaration,
+    unary_operator::unary_operator_expression, variable_declaration::variable_declaration,
     ExpressionContext,
 };
 use ast::{Expression, IResult, ParserInput};
@@ -27,6 +28,8 @@ pub fn basic_expression<'a>(
             move |input| record_assignment(context, input),
             Expression::RecordAssignment,
         ),
+        map(type_declaration, Expression::TypeDeclaration),
+        map(variable_declaration, Expression::Declaration),
     ))
 }
 

--- a/rust/parser/src/document.rs
+++ b/rust/parser/src/document.rs
@@ -3,8 +3,8 @@ use crate::{
     variable_declaration::variable_declaration, ExpressionContext,
 };
 use ast::{
-    DocumentNode, DocumentValue, Expression, IResult, ImportNode, ParserInput, TopLevelDeclaration,
-    TypeDeclarationNode, VariableDeclarationNode,
+    DeclarationNode, DocumentNode, DocumentValue, Expression, IResult, ImportNode, ParserInput,
+    TopLevelDeclaration, TypeDeclarationNode,
 };
 use nom::{
     branch::alt,
@@ -19,7 +19,7 @@ enum DocumentElement<'a> {
     None,
     Import(ImportNode<'a>),
     TypeDeclaration(TypeDeclarationNode<'a>),
-    VariableDeclaration(VariableDeclarationNode<'a>),
+    VariableDeclaration(DeclarationNode<'a>),
     Expression(Expression<'a>),
 }
 

--- a/rust/parser/src/type_declaration.rs
+++ b/rust/parser/src/type_declaration.rs
@@ -26,7 +26,7 @@ pub fn type_declaration(input: ParserInput) -> IResult<TypeDeclarationNode> {
         |(consumed, (identifier, type_expression))| TypeDeclarationNode {
             value: TypeDeclarationValue {
                 identifier,
-                type_expression,
+                type_expression: Box::new(type_expression),
             },
             source: consumed,
         },
@@ -57,11 +57,8 @@ mod test {
         let input = ParserInput::new("Hello = World");
         let (_, declaration) = type_declaration(input.clone()).unwrap();
         assert!(matches!(
-            declaration.value,
-            TypeDeclarationValue {
-                type_expression: TypeExpression::Identifier(_),
-                ..
-            }
+            *declaration.value.type_expression,
+            TypeExpression::Identifier(_),
         ));
     }
 

--- a/rust/type_checker/src/apply_constraints.rs
+++ b/rust/type_checker/src/apply_constraints.rs
@@ -1,35 +1,47 @@
 use crate::{
     generic_nodes::{
-        get_generic_type_id, GenericDocument, GenericSourcedType, GenericVariableDeclaration,
+        get_generic_type_id, GenericDocument, GenericIdentifierExpression, GenericSourcedType,
+        GenericTopLevelDeclarationExpression,
     },
     parsed_expression_to_generic_expression::translate_parsed_expression_to_generic_expression,
     type_schema::TypeSchema,
     type_schema_substitutions::TypeSchemaSubstitutions,
 };
-use ast::{DocumentNode, ParsedNode, TopLevelDeclaration, VariableDeclarationValue};
-use typed_ast::TypedVariableDeclaration;
+use ast::{DeclarationValue, DocumentNode, ParsedNode, TopLevelDeclaration};
+use typed_ast::TypedDeclarationExpression;
 
-fn translate_variable_declaration<'a>(
-    input: TopLevelDeclaration<ParsedNode<'a, VariableDeclarationValue<'a>>>,
-) -> Result<TopLevelDeclaration<GenericVariableDeclaration<'a>>, ()> {
+fn translate_top_level_variable_declaration<'a>(
+    input: TopLevelDeclaration<ParsedNode<'a, DeclarationValue<'a>>>,
+) -> Result<TopLevelDeclaration<GenericTopLevelDeclarationExpression<'a>>, ()> {
     let identifier_name = input.declaration.value.identifier.value.name;
     let mut schema = TypeSchema::new();
     let mut substitutions = TypeSchemaSubstitutions::new();
     let expression = translate_parsed_expression_to_generic_expression(
         &mut schema,
         &mut substitutions,
-        input.declaration.value.expression,
+        *input.declaration.value.expression,
     )?;
     let type_id = get_generic_type_id(&expression);
     Ok(TopLevelDeclaration {
-        declaration: GenericVariableDeclaration {
-            declaration: TypedVariableDeclaration {
+        declaration: GenericTopLevelDeclarationExpression {
+            declaration: TypedDeclarationExpression {
                 declaration_type: GenericSourcedType {
+                    type_id,
+                    source_of_type: input.declaration.source.clone(),
+                },
+                expression_type: GenericSourcedType {
                     type_id,
                     source_of_type: input.declaration.source,
                 },
-                identifier_name,
-                expression,
+                identifier: GenericIdentifierExpression {
+                    expression_type: GenericSourcedType {
+                        type_id,
+                        source_of_type: input.declaration.value.identifier.source,
+                    },
+                    is_disregarded: input.declaration.value.identifier.value.is_disregarded,
+                    name: identifier_name,
+                },
+                value: expression,
             },
             schema,
             substitutions,
@@ -39,11 +51,13 @@ fn translate_variable_declaration<'a>(
 }
 
 pub fn apply_constraints(input: DocumentNode) -> Result<GenericDocument, ()> {
-    let mut variable_declarations: Vec<TopLevelDeclaration<GenericVariableDeclaration>> =
+    let mut variable_declarations: Vec<TopLevelDeclaration<GenericTopLevelDeclarationExpression>> =
         Vec::new();
     variable_declarations.reserve_exact(input.value.variable_declarations.len());
     for variable_declaration in input.value.variable_declarations {
-        variable_declarations.push(translate_variable_declaration(variable_declaration)?);
+        variable_declarations.push(translate_top_level_variable_declaration(
+            variable_declaration,
+        )?);
     }
     Ok(GenericDocument {
         imports: input.value.imports,

--- a/rust/type_checker/src/generic_nodes.rs
+++ b/rust/type_checker/src/generic_nodes.rs
@@ -7,8 +7,8 @@ use typed_ast::{
     TypedDeclarationExpression, TypedExpression, TypedFunctionExpression,
     TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
     TypedListExpression, TypedRecordAssignmentExpression, TypedRecordExpression,
-    TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclaration,
-    TypedUnaryOperatorExpression, TypedVariableDeclaration,
+    TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclarationExpression,
+    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,13 +35,17 @@ pub type GenericRecordAssignmentExpression<'a> =
 pub type GenericRecordExpression<'a> = TypedRecordExpression<GenericSourcedType<'a>>;
 pub type GenericStringLiteralExpression<'a> = TypedStringLiteralExpression<GenericSourcedType<'a>>;
 pub type GenericTagExpression<'a> = TypedTagExpression<GenericSourcedType<'a>>;
+pub type GenericTypeDeclarationExpression<'a> =
+    TypedTypeDeclarationExpression<GenericSourcedType<'a>>;
+pub type GenericTypeIdentifierExpression<'a> =
+    TypedTypeIdentifierExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GenericVariableDeclaration<'a> {
-    pub declaration: TypedVariableDeclaration<GenericSourcedType<'a>>,
+pub struct GenericTopLevelDeclarationExpression<'a> {
+    pub declaration: TypedDeclarationExpression<GenericSourcedType<'a>>,
     pub schema: TypeSchema,
     pub substitutions: TypeSchemaSubstitutions,
 }
@@ -49,8 +53,9 @@ pub struct GenericVariableDeclaration<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GenericDocument<'a> {
     pub imports: Vec<ImportNode<'a>>,
-    pub type_declarations: Vec<TopLevelDeclaration<TypedTypeDeclaration<GenericSourcedType<'a>>>>,
-    pub variable_declarations: Vec<TopLevelDeclaration<GenericVariableDeclaration<'a>>>,
+    pub type_declarations:
+        Vec<TopLevelDeclaration<TypedTypeDeclarationExpression<GenericSourcedType<'a>>>>,
+    pub variable_declarations: Vec<TopLevelDeclaration<GenericTopLevelDeclarationExpression<'a>>>,
     pub expressions: Vec<TypedExpression<GenericSourcedType<'a>>>,
 }
 
@@ -70,6 +75,8 @@ pub const fn get_generic_type_id(input: &GenericExpression) -> GenericTypeId {
         GenericExpression::RecordAssignment(node) => node.expression_type.type_id,
         GenericExpression::StringLiteral(node) => node.expression_type.type_id,
         GenericExpression::Tag(node) => node.expression_type.type_id,
+        GenericExpression::TypeDeclaration(node) => node.expression_type.type_id,
+        GenericExpression::TypeIdentifier(node) => node.expression_type.type_id,
         GenericExpression::UnaryOperator(node) => node.expression_type.type_id,
     }
 }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -4,7 +4,7 @@ use crate::{
     TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
-    TypedUnaryOperatorExpression, TypedVariableDeclaration,
+    TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -20,11 +20,12 @@ pub type ConcreteRecordExpression = TypedRecordExpression<ConcreteType>;
 pub type ConcreteRecordAssignmentExpression = TypedRecordAssignmentExpression<ConcreteType>;
 pub type ConcreteStringLiteralExpression = TypedStringLiteralExpression<ConcreteType>;
 pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
+pub type ConcreteTypeDeclarationExpression = TypedTypeDeclarationExpression<ConcreteType>;
+pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
 
-pub type ConcreteVariableDeclaration = TypedVariableDeclaration<ConcreteType>;
 pub type ConcreteDocument<'a> = TypedDocument<'a, ConcreteType>;
 
 impl ConcreteExpression {

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -23,6 +23,7 @@ pub struct TypedBooleanLiteralExpression<T> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedDeclarationExpression<T> {
+    pub declaration_type: T,
     pub expression_type: T,
     pub identifier: TypedIdentifierExpression<T>,
     pub value: TypedExpression<T>,
@@ -89,6 +90,19 @@ pub struct TypedTagExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedTypeDeclarationExpression<T> {
+    pub declaration_type: T,
+    pub expression_type: T,
+    pub identifier_name: TypedTypeIdentifierExpression<T>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedTypeIdentifierExpression<T> {
+    pub expression_type: T,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedUnaryOperatorExpression<T> {
     pub expression_type: T,
     pub symbol: UnaryOperatorSymbol,
@@ -111,26 +125,15 @@ pub enum TypedExpression<T> {
     RecordAssignment(Box<TypedRecordAssignmentExpression<T>>),
     StringLiteral(Box<TypedStringLiteralExpression<T>>),
     Tag(Box<TypedTagExpression<T>>),
+    TypeDeclaration(Box<TypedTypeDeclarationExpression<T>>),
+    TypeIdentifier(Box<TypedTypeIdentifierExpression<T>>),
     UnaryOperator(Box<TypedUnaryOperatorExpression<T>>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypedTypeDeclaration<T> {
-    pub declaration_type: T,
-    pub identifier_name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypedVariableDeclaration<T> {
-    pub declaration_type: T,
-    pub identifier_name: String,
-    pub expression: TypedExpression<T>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedDocument<'a, T> {
     pub imports: Vec<ImportNode<'a>>,
-    pub type_declarations: Vec<TopLevelDeclaration<TypedTypeDeclaration<T>>>,
-    pub variable_declarations: Vec<TopLevelDeclaration<TypedVariableDeclaration<T>>>,
+    pub type_declarations: Vec<TopLevelDeclaration<TypedTypeDeclarationExpression<T>>>,
+    pub variable_declarations: Vec<TopLevelDeclaration<TypedDeclarationExpression<T>>>,
     pub expressions: Vec<TypedExpression<T>>,
 }


### PR DESCRIPTION
There may be future cleanup needed, but at least this will let us use variable declarations in functions for now

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"record-assignment","parentHead":"384bcf79dcb5ea6ead3c39311b7f46a516399540","parentPull":116,"trunk":"main"}
```
-->
