### PR TITLE
Refactor resolving concrete types

### DIFF
--- a/rust/compiler/src/lib.rs
+++ b/rust/compiler/src/lib.rs
@@ -24,9 +24,6 @@ pub fn compile_buri_file(contents: &str) -> Result<String, CompilationError> {
         Ok(items) => items,
         Err(error) => return Err(CompilationError::TypeError(error)),
     };
-    let concrete_document = match resolve_concrete_types(type_schema, generic_document) {
-        Ok(document) => document,
-        Err(error) => return Err(CompilationError::TypeResolutionError(error)),
-    };
+    let concrete_document = resolve_concrete_types(type_schema, generic_document);
     Ok(print_js_document(&concrete_document))
 }

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -1,5 +1,6 @@
 use crate::{constraints::Constraint, parsed_constraint::ParsedConstraint, scope::Scope, TypeId};
 use std::collections::HashMap;
+use typed_ast::{ConcreteType, PrimitiveType};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CanonicalIds(Vec<TypeId>);
@@ -86,10 +87,12 @@ impl TypeSchema {
         };
         Ok(())
     }
-    /// TODO(nick): update this function to work with
-    pub fn get_constraints(&mut self, type_id: TypeId) -> Option<&Vec<Constraint>> {
-        let _ = self.get_canonical_id(type_id);
-        None
+    pub fn get_concrete_type_from_id(&self, type_id: TypeId) -> ConcreteType {
+        let canonical_id = self.get_canonical_id(type_id);
+        self.constraints.get(&canonical_id).map_or_else(
+            || ConcreteType::Primitive(PrimitiveType::CompilerBoolean),
+            |parsed_constraint| parsed_constraint.to_concrete_type(self),
+        )
     }
     pub fn get_canonical_id(&self, type_id: TypeId) -> TypeId {
         self.types.get_canonical_id(type_id)

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -13,7 +13,7 @@ pub struct ConcreteFunctionType {
     /// If a function does not take any arguments, then the vec is empty.
     pub argument_types: Vec<ConcreteType>,
     /// return_type = None means that the function does not return a value.
-    pub return_type: Option<ConcreteType>,
+    pub return_type: ConcreteType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,7 +77,7 @@ impl ConcreteType {
     pub fn default_binary_operator_for_test() -> Self {
         Self::Function(Box::new(ConcreteFunctionType {
             argument_types: vec![],
-            return_type: None,
+            return_type: Self::Primitive(PrimitiveType::Str),
         }))
     }
 
@@ -92,7 +92,7 @@ impl ConcreteType {
     pub fn default_function_for_test() -> Self {
         Self::Function(Box::new(ConcreteFunctionType {
             argument_types: vec![],
-            return_type: None,
+            return_type: Self::Primitive(PrimitiveType::Str),
         }))
     }
 }


### PR DESCRIPTION
Makes type resolution work with the new `ParsedConstraint` struct.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
