### PR TITLE
Resolve function arguments to concrete types (Fixes B-210)

### DIFF
--- a/rust/type_checker/src/resolve_concrete_types.rs
+++ b/rust/type_checker/src/resolve_concrete_types.rs
@@ -105,6 +105,18 @@ fn resolve_function(
     }))
 }
 
+fn resolve_function_arguments(
+    simplified_schema: &mut TypeSchema,
+    generic_function_arguments: Vec<GenericExpression>,
+) -> ConcreteExpression {
+    ConcreteExpression::FunctionArguments(
+        generic_function_arguments
+            .into_iter()
+            .map(|x| resolve_expression(simplified_schema, x))
+            .collect(),
+    )
+}
+
 fn resolve_identifier(
     simplified_schema: &mut TypeSchema,
     generic_identifier: GenericIdentifierExpression,
@@ -265,7 +277,9 @@ fn resolve_expression(
         GenericExpression::Function(generic_function) => {
             resolve_function(simplified_schema, *generic_function)
         }
-        // TODO(aaron) GenericExpression::FunctionArguments
+        GenericExpression::FunctionArguments(generic_function_arguments) => {
+            resolve_function_arguments(simplified_schema, generic_function_arguments)
+        }
         GenericExpression::Identifier(generic_identifier) => ConcreteExpression::Identifier(
             Box::new(resolve_identifier(simplified_schema, *generic_identifier)),
         ),


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"resolve-function-argument-names","parentHead":"1f77ada68410619f69c06a95904849852f24b432","parentPull":127,"trunk":"main"}
```
-->
