### PR TITLE
Remove todo comment (fixes B-221)

### DIFF
--- a/rust/type_checker/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/src/parsed_expression_to_generic_expression.rs
@@ -1317,8 +1317,6 @@ mod test {
                 source: ParserInput::new(""),
                 value: FunctionApplicationArgumentsValue { arguments: vec![] },
             });
-        // TODO(B-221): Remove the `let _ = ` and add .unwrap() to ensure this
-        // never errors.
         let _ = translate_parsed_expression_to_generic_expression(&mut schema, expression);
         assert_eq!(schema.count_ids(), 0);
     }


### PR DESCRIPTION
As we discussed via email, `translate_parsed_expression_to_generic_expression` should intentionally error here, rendering this todo comment unnecessary.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"resolve-function-arguments","parentHead":"6905e378ac676f82629aeeca5c9913e9944a4b1f","parentPull":128,"trunk":"main"}
```
-->
