### PR TITLE
Allow comments at the end of declarations (Fixes B-224)

### DIFF
--- a/rust/parser/src/intra_expression_whitespace.rs
+++ b/rust/parser/src/intra_expression_whitespace.rs
@@ -165,4 +165,14 @@ mod test {
         let result = intra_expression_whitespace(ExpressionContext::new())(input);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn parses_comment_that_ends_file() {
+        let input = ParserInput::new("-- comment");
+        let result = intra_expression_whitespace(
+            ExpressionContext::new().allow_newlines_in_expressions(),
+        )(input);
+        let (remainder, _) = result.unwrap();
+        assert!(remainder.is_empty());
+    }
 }

--- a/tests/js/valid/comments/end-of-line.buri
+++ b/tests/js/valid/comments/end-of-line.buri
@@ -1,0 +1,1 @@
+hello = "hello" -- this is a comment


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
