### PR TITLE
Ensure mixed list types do not type check (Fixes B-257)

### DIFF
--- a/rust/type_checker/src/parsed_constraint.rs
+++ b/rust/type_checker/src/parsed_constraint.rs
@@ -674,7 +674,9 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_id = schema.make_id();
         let canonical_id = schema.make_id();
-        schema.set_types_equal(type_id, canonical_id).unwrap();
+        schema
+            .set_equal_to_canonical_type(type_id, canonical_id)
+            .unwrap();
         let mut parsed_constraint =
             ParsedConstraint::new(Constraint::EqualToPrimitive(PrimitiveType::Num), &schema);
         let new_constraint = ParsedConstraint::new(
@@ -1024,7 +1026,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasMethod(HasMethodConstraint {
                 method_name: "foo".to_string(),
@@ -1174,7 +1176,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(Constraint::ListOfType(type_a), &schema);
         let other_constraint = ParsedConstraint::new(Constraint::ListOfType(type_b), &schema);
         assert!(parsed_constraint.is_compatible_with(&other_constraint, &schema));
@@ -1312,7 +1314,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::TagAtMost(TagAtMostConstraint {
                 tags: HashMap::from([("foo".to_string(), vec![type_a])]),
@@ -1682,7 +1684,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasTag(HasTagConstraint {
                 tag_name: String::from("foo"),
@@ -1860,7 +1862,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::TagAtMost(TagAtMostConstraint {
                 tags: HashMap::from([(String::from("foo"), vec![type_a])]),
@@ -2017,7 +2019,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::FieldAtMost(FieldAtMostConstraint {
                 fields: HashMap::from([(String::from("foo"), type_a)]),
@@ -2180,7 +2182,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasField(HasFieldConstraint {
                 field_name: String::from("foo"),
@@ -2348,7 +2350,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasField(HasFieldConstraint {
                 field_name: String::from("foo"),
@@ -2507,7 +2509,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let type_a = schema.make_id();
         let type_b = schema.make_id();
-        schema.set_types_equal(type_a, type_b).unwrap();
+        schema.set_equal_to_canonical_type(type_a, type_b).unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::FieldAtMost(FieldAtMostConstraint {
                 fields: HashMap::from([(String::from("foo"), type_a)]),
@@ -2605,7 +2607,7 @@ mod test {
         let return_type_a = schema.make_id();
         let return_type_b = schema.make_id();
         schema
-            .set_types_equal(return_type_a, return_type_b)
+            .set_equal_to_canonical_type(return_type_a, return_type_b)
             .unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasFunctionShape(HasFunctionShape {
@@ -2731,7 +2733,7 @@ mod test {
         let argument_type_a = schema.make_id();
         let argument_type_b = schema.make_id();
         schema
-            .set_types_equal(argument_type_a, argument_type_b)
+            .set_equal_to_canonical_type(argument_type_a, argument_type_b)
             .unwrap();
         let parsed_constraint = ParsedConstraint::new(
             Constraint::HasFunctionShape(HasFunctionShape {

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -103,11 +103,15 @@ impl TypeSchema {
     pub fn get_total_canonical_ids(&mut self) -> usize {
         self.types.get_total_canonical_ids()
     }
-    pub fn set_types_equal(&mut self, type_a: TypeId, type_b: TypeId) -> Result<(), ()> {
-        if !self.types_are_compatible(type_a, type_b) {
+    pub fn set_equal_to_canonical_type(
+        &mut self,
+        canonical_type_id: TypeId,
+        other_type_id: TypeId,
+    ) -> Result<(), ()> {
+        if !self.types_are_compatible(canonical_type_id, other_type_id) {
             return Err(());
         }
-        self.types.set_types_equal(type_a, type_b);
+        self.types.set_types_equal(canonical_type_id, other_type_id);
         Ok(())
     }
     pub fn types_are_compatible(&self, base_type: TypeId, other_type: TypeId) -> bool {
@@ -162,7 +166,7 @@ mod test {
         let mut type_schema = TypeSchema::new();
         let id_a = type_schema.make_id();
         let id_b = type_schema.make_id();
-        type_schema.set_types_equal(id_a, id_b).unwrap();
+        type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
         assert_eq!(type_schema.get_canonical_id(id_a), id_b);
         assert_eq!(type_schema.get_canonical_id(id_b), id_b);
     }
@@ -173,8 +177,8 @@ mod test {
         let id_a = type_schema.make_id();
         let id_b = type_schema.make_id();
         let id_c = type_schema.make_id();
-        type_schema.set_types_equal(id_a, id_b).unwrap();
-        type_schema.set_types_equal(id_b, id_c).unwrap();
+        type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
+        type_schema.set_equal_to_canonical_type(id_b, id_c).unwrap();
         assert_eq!(type_schema.get_canonical_id(id_a), id_c);
     }
 
@@ -193,8 +197,8 @@ mod test {
         let id_a = type_schema.make_id();
         let id_b = type_schema.make_id();
         let id_c = type_schema.make_id();
-        type_schema.set_types_equal(id_a, id_b).unwrap();
-        type_schema.set_types_equal(id_b, id_c).unwrap();
+        type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
+        type_schema.set_equal_to_canonical_type(id_b, id_c).unwrap();
         assert_eq!(type_schema.count_ids(), 3);
     }
 
@@ -213,8 +217,8 @@ mod test {
         let id_a = type_schema.make_id();
         let id_b = type_schema.make_id();
         let id_c = type_schema.make_id();
-        type_schema.set_types_equal(id_a, id_b).unwrap();
-        type_schema.set_types_equal(id_b, id_c).unwrap();
+        type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
+        type_schema.set_equal_to_canonical_type(id_b, id_c).unwrap();
         assert_eq!(type_schema.get_total_canonical_ids(), 1);
     }
 }

--- a/tests/js/invalid/list/mixed-types.buri
+++ b/tests/js/invalid/list/mixed-types.buri
@@ -1,0 +1,2 @@
+-- types are mixed
+mixed = [1, "two"]


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"end-of-line-comment","parentHead":"dc2e08abdbbfff72b2ed6629c6c461c2199e59e3","parentPull":131,"trunk":"main"}
```
-->
