### PR TITLE
Prohibit adding new fields to records via record assignment (Fixes B-261)

### DIFF
--- a/rust/type_checker/src/parsed_constraint.rs
+++ b/rust/type_checker/src/parsed_constraint.rs
@@ -121,9 +121,9 @@ impl CategoryConstraints {
             (
                 Self::Record(RecordConstraints::ClosedFields(self_items)),
                 Self::Record(RecordConstraints::OpenFields(other_items)),
-            ) => self_items.iter().all(|(name, type_id)| {
-                other_items.get(name).map_or(false, |other_type_id| {
-                    schema.types_are_compatible(*type_id, *other_type_id)
+            ) => other_items.iter().all(|(name, other_type_id)| {
+                self_items.get(name).map_or(false, |self_type_id| {
+                    schema.types_are_compatible(*other_type_id, *self_type_id)
                 })
             }),
             (
@@ -675,7 +675,7 @@ mod test {
         let type_id = schema.make_id();
         let canonical_id = schema.make_id();
         schema
-            .set_equal_to_canonical_type(type_id, canonical_id)
+            .set_equal_to_canonical_type(canonical_id, type_id)
             .unwrap();
         let mut parsed_constraint =
             ParsedConstraint::new(Constraint::EqualToPrimitive(PrimitiveType::Num), &schema);
@@ -1393,9 +1393,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: Vec::new(),
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), Vec::new())]),
             }),
             &schema,
         );
@@ -1421,9 +1420,8 @@ mod test {
         );
         parsed_constraint.add_constraints(new_constraint, &schema.types);
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: Vec::new(),
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), Vec::new())]),
             }),
             &schema,
         );
@@ -1441,9 +1439,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("bar"),
-                tag_content_types: Vec::new(),
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("bar".to_string(), Vec::new())]),
             }),
             &schema,
         );
@@ -1462,9 +1459,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: vec![type_id],
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), vec![type_id])]),
             }),
             &schema,
         );
@@ -1483,9 +1479,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: vec![type_id],
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), vec![type_id])]),
             }),
             &schema,
         );
@@ -1505,9 +1500,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: vec![type_b],
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), vec![type_b])]),
             }),
             &schema,
         );
@@ -1533,9 +1527,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: vec![type_b],
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), vec![type_b])]),
             }),
             &schema,
         );
@@ -1561,9 +1554,8 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::HasTag(HasTagConstraint {
-                tag_name: String::from("foo"),
-                tag_content_types: vec![type_b],
+            Constraint::TagAtMost(TagAtMostConstraint {
+                tags: HashMap::from([("foo".to_string(), vec![type_b])]),
             }),
             &schema,
         );
@@ -2435,8 +2427,9 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::FieldAtMost(FieldAtMostConstraint {
-                fields: HashMap::from([(String::from("foo"), type_id)]),
+            Constraint::HasField(HasFieldConstraint {
+                field_name: String::from("foo"),
+                field_type: type_id,
             }),
             &schema,
         );
@@ -2457,8 +2450,9 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::FieldAtMost(FieldAtMostConstraint {
-                fields: HashMap::from([(String::from("foo"), type_id)]),
+            Constraint::HasField(HasFieldConstraint {
+                field_name: String::from("foo"),
+                field_type: type_id,
             }),
             &schema,
         );
@@ -2476,8 +2470,9 @@ mod test {
             &schema,
         );
         let other_constraint = ParsedConstraint::new(
-            Constraint::FieldAtMost(FieldAtMostConstraint {
-                fields: HashMap::from([(String::from("bar"), type_id)]),
+            Constraint::HasField(HasFieldConstraint {
+                field_name: String::from("bar"),
+                field_type: type_id,
             }),
             &schema,
         );

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -41,10 +41,10 @@ impl CanonicalIds {
     fn set_types_equal(&mut self, type_a: TypeId, type_b: TypeId) {
         let canonical_a = self.get_canonical_id(type_a);
         let canonical_b = self.get_canonical_id(type_b);
-        self.0[canonical_a] = canonical_b;
+        self.0[canonical_b] = canonical_a;
         // Makes future canonical id lookups faster.
-        self.0[type_a] = canonical_b;
-        self.0[type_b] = canonical_b;
+        self.0[type_a] = canonical_a;
+        self.0[type_b] = canonical_a;
     }
 }
 
@@ -167,8 +167,8 @@ mod test {
         let id_a = type_schema.make_id();
         let id_b = type_schema.make_id();
         type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
-        assert_eq!(type_schema.get_canonical_id(id_a), id_b);
-        assert_eq!(type_schema.get_canonical_id(id_b), id_b);
+        assert_eq!(type_schema.get_canonical_id(id_a), id_a);
+        assert_eq!(type_schema.get_canonical_id(id_b), id_a);
     }
 
     #[test]
@@ -179,7 +179,7 @@ mod test {
         let id_c = type_schema.make_id();
         type_schema.set_equal_to_canonical_type(id_a, id_b).unwrap();
         type_schema.set_equal_to_canonical_type(id_b, id_c).unwrap();
-        assert_eq!(type_schema.get_canonical_id(id_a), id_c);
+        assert_eq!(type_schema.get_canonical_id(id_c), id_a);
     }
 
     #[test]

--- a/tests/js/invalid/record/add-new-field.buri
+++ b/tests/js/invalid/record/add-new-field.buri
@@ -1,0 +1,4 @@
+-- You cannot add new fields to a record via record RecordAssignment
+
+alice = { name: "Alice" }
+withAge = { alice | age: 42 }


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"test-export","parentHead":"7c65fa1d364982ad9c73d82f0140b2c53575a5f0","parentPull":138,"trunk":"main"}
```
-->
