### PR TITLE
Add error type for type checking error

### DIFF
--- a/rust/compiler/src/lib.rs
+++ b/rust/compiler/src/lib.rs
@@ -1,11 +1,11 @@
 use js_backend::print_js_document;
 use parser::parse_buri_file;
-use type_checker::{apply_constraints, resolve_concrete_types};
+use type_checker::{apply_constraints, resolve_concrete_types, TypeCheckingError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompilationError {
     ParseError(String),
-    TypeError(()),
+    TypeError(TypeCheckingError),
     TypeResolutionError(()),
 }
 

--- a/rust/type_checker/src/apply_constraints.rs
+++ b/rust/type_checker/src/apply_constraints.rs
@@ -10,7 +10,7 @@ use ast::{DeclarationValue, DocumentNode, ParsedNode, TopLevelDeclaration, TypeD
 fn translate_top_level_variable_declaration<'a>(
     schema: &mut TypeSchema,
     input: TopLevelDeclaration<ParsedNode<'a, DeclarationValue<'a>>>,
-) -> Result<TopLevelDeclaration<GenericDeclarationExpression<'a>>, ()> {
+) -> Result<TopLevelDeclaration<GenericDeclarationExpression<'a>>, TypeCheckingError> {
     Ok(TopLevelDeclaration {
         declaration: translate_declaration(schema, input.declaration)?,
         is_exported: input.is_exported,
@@ -20,14 +20,16 @@ fn translate_top_level_variable_declaration<'a>(
 fn translate_top_level_type_declaration<'a>(
     schema: &mut TypeSchema,
     input: TopLevelDeclaration<TypeDeclarationNode<'a>>,
-) -> Result<TopLevelDeclaration<GenericTypeDeclarationExpression<'a>>, ()> {
+) -> Result<TopLevelDeclaration<GenericTypeDeclarationExpression<'a>>, TypeCheckingError> {
     Ok(TopLevelDeclaration {
         declaration: translate_type_declaration(schema, input.declaration)?,
         is_exported: input.is_exported,
     })
 }
 
-pub fn apply_constraints(input: DocumentNode) -> Result<(GenericDocument, TypeSchema), ()> {
+pub fn apply_constraints(
+    input: DocumentNode,
+) -> Result<(GenericDocument, TypeSchema), TypeCheckingError> {
     let mut schema = TypeSchema::new();
     let mut variable_declarations: Vec<TopLevelDeclaration<GenericDeclarationExpression>> =
         Vec::new();
@@ -58,4 +60,19 @@ pub fn apply_constraints(input: DocumentNode) -> Result<(GenericDocument, TypeSc
         },
         schema,
     ))
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum TypeCheckingError {
+    ConstraintsNotCompatible,
+    DuplicateTagNamesInTagGroup,
+    FieldLookupDoesNotUseIdentifier,
+    FunctionApplicationDoesNotUseFunctionArguments,
+    IdentifierNotFound,
+    MethodLookupDoesNotUseIdentifier,
+    TypeIdentifierNotFound,
+    TypeIdentifierTypeNotFound,
+    TypesAreNotCompatible,
+    UnreachableBlockFinalExpression,
+    UnreachableFunctionApplicationArgumentExpression,
 }

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -9,5 +9,5 @@ mod type_schema;
 
 type TypeId = usize;
 
-pub use apply_constraints::apply_constraints;
+pub use apply_constraints::{apply_constraints, TypeCheckingError};
 pub use resolve_concrete_types::resolve_concrete_types;

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -1,4 +1,7 @@
-use crate::{constraints::Constraint, parsed_constraint::ParsedConstraint, scope::Scope, TypeId};
+use crate::{
+    apply_constraints::TypeCheckingError, constraints::Constraint,
+    parsed_constraint::ParsedConstraint, scope::Scope, TypeId,
+};
 use std::collections::HashMap;
 use typed_ast::{ConcreteType, PrimitiveType};
 
@@ -67,7 +70,11 @@ impl TypeSchema {
         self.types.make_id()
     }
     /// Insert a new constraint for a given type.
-    pub fn add_constraint(&mut self, type_id: TypeId, constraint: Constraint) -> Result<(), ()> {
+    pub fn add_constraint(
+        &mut self,
+        type_id: TypeId,
+        constraint: Constraint,
+    ) -> Result<(), TypeCheckingError> {
         let canonical_id = self.get_canonical_id(type_id);
         // Get the existing parsed constraint with an immutable reference so we can still
         // use the type schema.
@@ -79,7 +86,7 @@ impl TypeSchema {
                     parsed_constraint.add_constraints(new_constraint, &self.types);
                 }
             } else {
-                return Err(());
+                return Err(TypeCheckingError::ConstraintsNotCompatible);
             }
         } else {
             self.constraints
@@ -107,9 +114,9 @@ impl TypeSchema {
         &mut self,
         canonical_type_id: TypeId,
         other_type_id: TypeId,
-    ) -> Result<(), ()> {
+    ) -> Result<(), TypeCheckingError> {
         if !self.types_are_compatible(canonical_type_id, other_type_id) {
-            return Err(());
+            return Err(TypeCheckingError::TypesAreNotCompatible);
         }
         self.types.set_types_equal(canonical_type_id, other_type_id);
         Ok(())


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
