### PR TITLE
Add Framework for Compiler Error Messages

### DIFF
--- a/rust/compiler/src/lib.rs
+++ b/rust/compiler/src/lib.rs
@@ -1,13 +1,6 @@
 use js_backend::print_js_document;
 use parser::parse_buri_file;
-use type_checker::{apply_constraints, resolve_concrete_types, TypeCheckingError};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CompilationError {
-    ParseError(String),
-    TypeError(TypeCheckingError),
-    TypeResolutionError(()),
-}
+use type_checker::{apply_constraints, resolve_concrete_types};
 
 /// Compiles a single Buri file. Do not use to compile Buri programs with
 /// multiple files.
@@ -15,14 +8,22 @@ pub enum CompilationError {
 /// This function accepts the string contents of the Buri file, then returns
 /// the compiled JS output (or an error if the input is invalid). The caller
 /// must read the Buri file itself—this function does not do that.
-pub fn compile_buri_file(contents: &str) -> Result<String, CompilationError> {
+pub fn compile_buri_file(contents: &str) -> Result<String, String> {
     let parsed_ast = match parse_buri_file(contents) {
         Ok(ast) => ast,
-        Err(error) => return Err(CompilationError::ParseError(error)),
+        Err(error) => {
+            let mut message = "Parsing Error: ".to_owned();
+            message.push_str(error.as_str());
+            return Err(message);
+        }
     };
     let (generic_document, type_schema) = match apply_constraints(parsed_ast) {
         Ok(items) => items,
-        Err(error) => return Err(CompilationError::TypeError(error)),
+        Err(error) => {
+            let mut message = "Type Checking Error: ".to_owned();
+            message.push_str(error.as_str());
+            return Err(message);
+        }
     };
     let concrete_document = resolve_concrete_types(type_schema, generic_document);
     Ok(print_js_document(&concrete_document))

--- a/rust/e2e/src/lib.rs
+++ b/rust/e2e/src/lib.rs
@@ -38,10 +38,15 @@ fn get_directories() -> Result<(PathBuf, PathBuf, PathBuf), ()> {
     ))
 }
 
+struct FileFailedWithReason {
+    file_path: String,
+    reason: String,
+}
+
 /// Returns a vector of all file paths that could be built (when they
 /// shouldn't).
 #[allow(clippy::unwrap_used)] // this is essentially a test
-fn build_valid_files(workspace_directory: &Path, directory: &Path) -> Vec<String> {
+fn build_valid_files(workspace_directory: &Path, directory: &Path) -> Vec<FileFailedWithReason> {
     let files = WalkDir::new(directory)
         .into_iter()
         .filter_map(std::result::Result::ok)
@@ -53,9 +58,8 @@ fn build_valid_files(workspace_directory: &Path, directory: &Path) -> Vec<String
     let mut failed_builds = Vec::new();
     for file_path in files {
         if let Ok(contents) = std::fs::read_to_string(file_path.path()) {
-            compile_buri_file(&contents).map_or_else(
-                |_| failed_builds.push(format!("{file_path:?}")),
-                |new_contents| {
+            match compile_buri_file(&contents) {
+                Ok(new_contents) => {
                     let mut output_path =
                         workspace_directory.join(PathBuf::from(".buri/dist").join(PathBuf::from(
                             file_path.path().strip_prefix(workspace_directory).unwrap(),
@@ -65,10 +69,19 @@ fn build_valid_files(workspace_directory: &Path, directory: &Path) -> Vec<String
                     let mut output = File::create(output_path).unwrap();
                     write!(output, "{new_contents}").unwrap();
                     println!("PASS: {file_path:?} built as expected");
-                },
-            );
+                }
+                Err(error) => {
+                    failed_builds.push(FileFailedWithReason {
+                        file_path: format!("{file_path:?}"),
+                        reason: error,
+                    });
+                }
+            }
         } else {
-            failed_builds.push(format!("{file_path:?}"));
+            failed_builds.push(FileFailedWithReason {
+                file_path: format!("{file_path:?}"),
+                reason: "E2E: Error loading file".to_owned(),
+            });
         };
     }
     failed_builds
@@ -107,7 +120,8 @@ pub fn build_tests() -> Result<(), ()> {
     let invalid_test_errors = build_invalid_files(&invalid_directory);
     let valid_test_errors = build_valid_files(&workspace_directory, &valid_directory);
     for error in &valid_test_errors {
-        println!("FAIL: {error} could not be built");
+        println!("FAIL: {0} could not be built", error.file_path);
+        println!("REASON: {0}", error.reason);
     }
     for error in &invalid_test_errors {
         println!("FAIL: {error} unexpectedly built successfully");

--- a/rust/type_checker/src/apply_constraints.rs
+++ b/rust/type_checker/src/apply_constraints.rs
@@ -10,7 +10,7 @@ use ast::{DeclarationValue, DocumentNode, ParsedNode, TopLevelDeclaration, TypeD
 fn translate_top_level_variable_declaration<'a>(
     schema: &mut TypeSchema,
     input: TopLevelDeclaration<ParsedNode<'a, DeclarationValue<'a>>>,
-) -> Result<TopLevelDeclaration<GenericDeclarationExpression<'a>>, TypeCheckingError> {
+) -> Result<TopLevelDeclaration<GenericDeclarationExpression<'a>>, String> {
     Ok(TopLevelDeclaration {
         declaration: translate_declaration(schema, input.declaration)?,
         is_exported: input.is_exported,
@@ -20,16 +20,14 @@ fn translate_top_level_variable_declaration<'a>(
 fn translate_top_level_type_declaration<'a>(
     schema: &mut TypeSchema,
     input: TopLevelDeclaration<TypeDeclarationNode<'a>>,
-) -> Result<TopLevelDeclaration<GenericTypeDeclarationExpression<'a>>, TypeCheckingError> {
+) -> Result<TopLevelDeclaration<GenericTypeDeclarationExpression<'a>>, String> {
     Ok(TopLevelDeclaration {
         declaration: translate_type_declaration(schema, input.declaration)?,
         is_exported: input.is_exported,
     })
 }
 
-pub fn apply_constraints(
-    input: DocumentNode,
-) -> Result<(GenericDocument, TypeSchema), TypeCheckingError> {
+pub fn apply_constraints(input: DocumentNode) -> Result<(GenericDocument, TypeSchema), String> {
     let mut schema = TypeSchema::new();
     let mut variable_declarations: Vec<TopLevelDeclaration<GenericDeclarationExpression>> =
         Vec::new();
@@ -60,19 +58,4 @@ pub fn apply_constraints(
         },
         schema,
     ))
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum TypeCheckingError {
-    ConstraintsNotCompatible,
-    DuplicateTagNamesInTagGroup,
-    FieldLookupDoesNotUseIdentifier,
-    FunctionApplicationDoesNotUseFunctionArguments,
-    IdentifierNotFound,
-    MethodLookupDoesNotUseIdentifier,
-    TypeIdentifierNotFound,
-    TypeIdentifierTypeNotFound,
-    TypesAreNotCompatible,
-    UnreachableBlockFinalExpression,
-    UnreachableFunctionApplicationArgumentExpression,
 }

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -9,5 +9,5 @@ mod type_schema;
 
 type TypeId = usize;
 
-pub use apply_constraints::{apply_constraints, TypeCheckingError};
+pub use apply_constraints::apply_constraints;
 pub use resolve_concrete_types::resolve_concrete_types;

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -1,7 +1,4 @@
-use crate::{
-    apply_constraints::TypeCheckingError, constraints::Constraint,
-    parsed_constraint::ParsedConstraint, scope::Scope, TypeId,
-};
+use crate::{constraints::Constraint, parsed_constraint::ParsedConstraint, scope::Scope, TypeId};
 use std::collections::HashMap;
 use typed_ast::{ConcreteType, PrimitiveType};
 
@@ -74,7 +71,7 @@ impl TypeSchema {
         &mut self,
         type_id: TypeId,
         constraint: Constraint,
-    ) -> Result<(), TypeCheckingError> {
+    ) -> Result<(), String> {
         let canonical_id = self.get_canonical_id(type_id);
         // Get the existing parsed constraint with an immutable reference so we can still
         // use the type schema.
@@ -86,7 +83,7 @@ impl TypeSchema {
                     parsed_constraint.add_constraints(new_constraint, &self.types);
                 }
             } else {
-                return Err(TypeCheckingError::ConstraintsNotCompatible);
+                return Err("ConstraintsNotCompatible".to_owned());
             }
         } else {
             self.constraints
@@ -114,9 +111,9 @@ impl TypeSchema {
         &mut self,
         canonical_type_id: TypeId,
         other_type_id: TypeId,
-    ) -> Result<(), TypeCheckingError> {
+    ) -> Result<(), String> {
         if !self.types_are_compatible(canonical_type_id, other_type_id) {
-            return Err(TypeCheckingError::TypesAreNotCompatible);
+            return Err("TypesAreNotCompatible".to_owned());
         }
         self.types.set_types_equal(canonical_type_id, other_type_id);
         Ok(())


### PR DESCRIPTION
When a Buri file is expected to compile, but does not, the compiler will explain why the file failed to compile.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
