### PR TITLE
Test that tags can have a name and hold data (Fixes B-265 and B-266)

### DIFF
--- a/tests/js/valid/tags/declaration.buri
+++ b/tests/js/valid/tags/declaration.buri
@@ -3,3 +3,9 @@ booleanTrue = #true
 
 @export
 booleanFalse = #false
+
+@export
+hello = #hello
+
+@export
+localHost = #ip(127, 0, 0, 1)

--- a/tests/js/valid/tags/declaration.test.js
+++ b/tests/js/valid/tags/declaration.test.js
@@ -1,5 +1,11 @@
-import { booleanFalse, booleanTrue } from "@tests/js/valid/tags/declaration.mjs"
+import {
+    booleanFalse,
+    booleanTrue,
+    hello,
+    localHost,
+} from "@tests/js/valid/tags/declaration.mjs"
 import { expect, it } from "bun:test"
+import { getTagContents, getTagName } from "../helpers"
 
 it("compiler boolean true", () => {
     expect(booleanTrue).toBe(true)
@@ -7,4 +13,12 @@ it("compiler boolean true", () => {
 
 it("compiler boolean false", () => {
     expect(booleanFalse).toBe(false)
+})
+
+it("tags can have a name", () => {
+    expect(getTagName(hello)).toBe("hello")
+})
+
+it("tags can hold contents", () => {
+    expect(getTagContents(localHost)).toEqual([127, 0, 0, 1])
 })


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
