### PR TITLE
Add backtrace to type-checker error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ast"
 version = "0.1.0"
 dependencies = [
@@ -11,10 +26,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compiler"
@@ -35,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "js_backend"
 version = "0.1.0"
 dependencies = [
@@ -42,6 +90,12 @@ dependencies = [
  "parser",
  "typed_ast",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "memchr"
@@ -54,6 +108,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nom"
@@ -77,12 +140,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parser"
 version = "0.1.0"
 dependencies = [
  "ast",
  "nom",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "same-file"
@@ -98,6 +176,7 @@ name = "type_checker"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "backtrace",
  "parser",
  "typed_ast",
 ]

--- a/rust/type_checker/Cargo.toml
+++ b/rust/type_checker/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 ast = { path = "../ast" }
+backtrace = "0.3"
 parser = { path = "../parser" }
 typed_ast = { path = "../typed_ast" }

--- a/rust/type_checker/src/generate_backtrace_error.rs
+++ b/rust/type_checker/src/generate_backtrace_error.rs
@@ -1,0 +1,7 @@
+use backtrace::Backtrace;
+
+pub fn generate_backtrace_error(mut message: String) -> String {
+    message.push('\n');
+    message.push_str(&format!("{:?}", Backtrace::new()));
+    message
+}

--- a/rust/type_checker/src/lib.rs
+++ b/rust/type_checker/src/lib.rs
@@ -1,5 +1,6 @@
 mod apply_constraints;
 mod constraints;
+mod generate_backtrace_error;
 mod generic_nodes;
 mod parsed_constraint;
 mod parsed_expression_to_generic_expression;

--- a/rust/type_checker/src/type_schema.rs
+++ b/rust/type_checker/src/type_schema.rs
@@ -1,4 +1,7 @@
-use crate::{constraints::Constraint, parsed_constraint::ParsedConstraint, scope::Scope, TypeId};
+use crate::{
+    constraints::Constraint, generate_backtrace_error::generate_backtrace_error,
+    parsed_constraint::ParsedConstraint, scope::Scope, TypeId,
+};
 use std::collections::HashMap;
 use typed_ast::{ConcreteType, PrimitiveType};
 
@@ -83,7 +86,9 @@ impl TypeSchema {
                     parsed_constraint.add_constraints(new_constraint, &self.types);
                 }
             } else {
-                return Err("ConstraintsNotCompatible".to_owned());
+                return Err(generate_backtrace_error(
+                    "ConstraintsNotCompatible".to_owned(),
+                ));
             }
         } else {
             self.constraints
@@ -113,7 +118,7 @@ impl TypeSchema {
         other_type_id: TypeId,
     ) -> Result<(), String> {
         if !self.types_are_compatible(canonical_type_id, other_type_id) {
-            return Err("TypesAreNotCompatible".to_owned());
+            return Err(generate_backtrace_error("TypesAreNotCompatible".to_owned()));
         }
         self.types.set_types_equal(canonical_type_id, other_type_id);
         Ok(())


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
