### PR TITLE
Improve the e2e test error reporting

### DIFF
--- a/rust/e2e/src/main.rs
+++ b/rust/e2e/src/main.rs
@@ -1,5 +1,11 @@
 use e2e::build_tests;
 
-fn main() -> Result<(), ()> {
-    build_tests()
+fn main() -> Result<(), String> {
+    match build_tests() {
+        Ok(s) => {
+            println!("{s}");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
 }


### PR DESCRIPTION
Overall, now everything is cleaner and we can see how many tests pass and fail:

<img width="509" alt="Screenshot 2023-02-24 at 9 06 28 AM" src="https://user-images.githubusercontent.com/5659171/221242413-fcd1e665-ca7f-4a89-82f0-b36d5a1c2515.png">

<img width="1260" alt="Screenshot 2023-02-24 at 9 06 42 AM" src="https://user-images.githubusercontent.com/5659171/221242453-7760be72-ad46-4c35-8716-e4eb63f76509.png">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
