### PR TITLE
Test functions inside other functions (Fixes B-288)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "indoc"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2b9d82064e8a0226fddb3547f37f28eaa46d0fc210e275d835f08cf3b76a7"
+
+[[package]]
 name = "js_backend"
 version = "0.1.0"
 dependencies = [
@@ -154,6 +160,7 @@ name = "parser"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "indoc",
  "nom",
 ]
 
@@ -193,6 +200,7 @@ name = "type_checker_translator"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "indoc",
  "parser",
  "type_checker_errors",
  "type_checker_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 nom = "7.1.3"
 nom_locate = "4.1.0"
 walkdir = "2.3.2"
+indoc = "2.0.0"
 
 [toolchain]
 channel = "1.66.0"

--- a/rust/js_backend/src/expression/binary_operator.rs
+++ b/rust/js_backend/src/expression/binary_operator.rs
@@ -28,11 +28,11 @@ fn print_operator(operator: &BinaryOperatorSymbol) -> String {
         BinaryOperatorSymbol::Or => "||".to_string(),
         BinaryOperatorSymbol::Concatenate => "+".to_string(),
         BinaryOperatorSymbol::MethodLookup | BinaryOperatorSymbol::FieldLookup => ".".to_string(),
-        BinaryOperatorSymbol::FunctionApplication => unreachable!(),
+        BinaryOperatorSymbol::FunctionApplication => String::new(),
     }
 }
 
-fn get_format(operator: &BinaryOperatorSymbol) -> OperatorFormat {
+const fn get_format(operator: &BinaryOperatorSymbol) -> OperatorFormat {
     match operator {
         BinaryOperatorSymbol::Add
         | BinaryOperatorSymbol::Subtract
@@ -48,11 +48,11 @@ fn get_format(operator: &BinaryOperatorSymbol) -> OperatorFormat {
         | BinaryOperatorSymbol::GreaterThanOrEqualTo => OperatorFormat::Method,
         BinaryOperatorSymbol::Concatenate
         | BinaryOperatorSymbol::And
-        | BinaryOperatorSymbol::Or => OperatorFormat::Parenthesized,
+        | BinaryOperatorSymbol::Or
+        | BinaryOperatorSymbol::FunctionApplication => OperatorFormat::Parenthesized,
         BinaryOperatorSymbol::MethodLookup | BinaryOperatorSymbol::FieldLookup => {
             OperatorFormat::Naked
         }
-        BinaryOperatorSymbol::FunctionApplication => unreachable!(),
     }
 }
 

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 ast = { path = "../ast" }
 nom.workspace = true
+indoc.workspace = true

--- a/rust/parser/src/basic_expression.rs
+++ b/rust/parser/src/basic_expression.rs
@@ -15,7 +15,10 @@ pub fn basic_expression<'a>(
         map(move |input| function(context, input), Expression::Function),
         parentheses,
         map(type_declaration, Expression::TypeDeclaration),
-        map(variable_declaration, Expression::Declaration),
+        map(
+            move |input| variable_declaration(context, input),
+            Expression::Declaration,
+        ),
         map(
             move |input| unary_operator_expression(context, input),
             Expression::UnaryOperator,

--- a/rust/parser/src/document.rs
+++ b/rust/parser/src/document.rs
@@ -31,7 +31,10 @@ fn declaration(input: ParserInput) -> IResult<DocumentElement> {
         ),
         // Newlines are required by variable_declarations, so we don't
         // need to add them here.
-        map(variable_declaration, DocumentElement::VariableDeclaration),
+        map(
+            move |input| variable_declaration(ExpressionContext::new(), input),
+            DocumentElement::VariableDeclaration,
+        ),
     ))(input)
 }
 

--- a/rust/type_checker/translator/Cargo.toml
+++ b/rust/type_checker/translator/Cargo.toml
@@ -13,3 +13,4 @@ type_checker_types = { path = "../types" }
 
 [dev-dependencies]
 parser = { path = "../../parser" }
+indoc.workspace = true

--- a/rust/type_checker/types/src/scope.rs
+++ b/rust/type_checker/types/src/scope.rs
@@ -1,3 +1,5 @@
+use type_checker_errors::generate_backtrace_error;
+
 use crate::TypeId;
 use std::collections::HashMap;
 
@@ -37,10 +39,20 @@ impl Scope {
         let answer = self.identifiers.get(identifier_name).copied();
         answer
     }
-    pub fn declare_identifier(&mut self, identifier_name: String, identifier_type: TypeId) {
+    pub fn declare_identifier(
+        &mut self,
+        identifier_name: String,
+        identifier_type: TypeId,
+    ) -> Result<(), String> {
+        if self.identifiers.get(&identifier_name).is_some() {
+            return Err(generate_backtrace_error(format!(
+                "Identifier {identifier_name} already declared in this scope"
+            )));
+        }
         self.identifiers
             .insert(identifier_name.clone(), identifier_type);
         self.stack.push(ScopeItem::Identifier(identifier_name));
+        Ok(())
     }
 }
 
@@ -72,9 +84,9 @@ mod test {
     #[test]
     fn adding_identifiers_to_scope_updates_the_stack() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         assert_eq!(
             scope.stack,
             vec![
@@ -88,9 +100,9 @@ mod test {
     #[test]
     fn adding_identifiers_to_scope_updates_the_identifiers() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         assert_eq!(
             scope.identifiers,
             vec![
@@ -106,9 +118,9 @@ mod test {
     #[test]
     fn ending_sub_scope_pops_all_identifiers_from_stack() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         scope.end_sub_scope();
         assert_eq!(scope.stack, Vec::new());
     }
@@ -116,13 +128,13 @@ mod test {
     #[test]
     fn ending_sub_scope_only_pops_identifiers_from_current_scope_in_the_stack() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         scope.start_sub_scope();
-        scope.declare_identifier("qux".to_string(), 3);
-        scope.declare_identifier("quux".to_string(), 4);
-        scope.declare_identifier("quuz".to_string(), 5);
+        scope.declare_identifier("qux".to_string(), 3).unwrap();
+        scope.declare_identifier("quux".to_string(), 4).unwrap();
+        scope.declare_identifier("quuz".to_string(), 5).unwrap();
         scope.end_sub_scope();
         assert_eq!(
             scope.stack,
@@ -137,9 +149,9 @@ mod test {
     #[test]
     fn ending_sub_scope_removes_identifiers_from_hash_map() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         scope.end_sub_scope();
         assert_eq!(scope.identifiers, HashMap::new());
     }
@@ -147,13 +159,13 @@ mod test {
     #[test]
     fn ending_sub_scope_removes_identifiers_from_current_scope_in_hash_map() {
         let mut scope = Scope::new();
-        scope.declare_identifier("foo".to_string(), 0);
-        scope.declare_identifier("bar".to_string(), 1);
-        scope.declare_identifier("baz".to_string(), 2);
+        scope.declare_identifier("foo".to_string(), 0).unwrap();
+        scope.declare_identifier("bar".to_string(), 1).unwrap();
+        scope.declare_identifier("baz".to_string(), 2).unwrap();
         scope.start_sub_scope();
-        scope.declare_identifier("qux".to_string(), 3);
-        scope.declare_identifier("quux".to_string(), 4);
-        scope.declare_identifier("quuz".to_string(), 5);
+        scope.declare_identifier("qux".to_string(), 3).unwrap();
+        scope.declare_identifier("quux".to_string(), 4).unwrap();
+        scope.declare_identifier("quuz".to_string(), 5).unwrap();
         scope.end_sub_scope();
         assert_eq!(
             scope.identifiers,

--- a/rust/type_checker/types/src/type_schema.rs
+++ b/rust/type_checker/types/src/type_schema.rs
@@ -146,10 +146,13 @@ impl TypeSchema {
 
     // TODO(aaron) B-279
     // #[cfg(test)]
-    pub fn make_identifier_for_test<S: Into<String>>(&mut self, identifier_name: S) -> TypeId {
+    pub fn make_identifier_for_test<S: Into<String>>(
+        &mut self,
+        identifier_name: S,
+    ) -> Result<TypeId, String> {
         let id = self.make_id();
-        self.scope.declare_identifier(identifier_name.into(), id);
-        id
+        self.scope.declare_identifier(identifier_name.into(), id)?;
+        Ok(id)
     }
 }
 

--- a/tests/js/valid/functions/closures.buri
+++ b/tests/js/valid/functions/closures.buri
@@ -1,2 +1,8 @@
 @export
 addN = (n) => (a) => a + n
+
+@export
+three = () =>
+    one = () => 1
+    two = () => 2
+    one() + two()

--- a/tests/js/valid/functions/closures.test.js
+++ b/tests/js/valid/functions/closures.test.js
@@ -1,4 +1,4 @@
-import { addN } from "@tests/js/valid/functions/closures.mjs"
+import { addN, three } from "@tests/js/valid/functions/closures.mjs"
 import { describe, expect, it } from "bun:test"
 
 describe("addN", () => {
@@ -12,5 +12,11 @@ describe("addN", () => {
         const add2 = addN(2)
         expect(add2(1).valueOf()).toEqual(3)
         expect(add2(2).valueOf()).toEqual(4)
+    })
+})
+
+describe("three", () => {
+    it("should return 3", () => {
+        expect(three().valueOf()).toEqual(3)
     })
 })


### PR DESCRIPTION
As a side benefit, this also exposed that we were checking for variable shadowing. So to get all the e2e tests to pass, I also had to fix that.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"if-branch-types","parentHead":"4c86175f93205854fe399b4d5d1080e90ba07c08","parentPull":160,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"if-branch-types","parentHead":"4c86175f93205854fe399b4d5d1080e90ba07c08","parentPull":160,"trunk":"main"}
```
-->
