### PR TITLE
Derive default trait to fix clippy warning

### DIFF
--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -232,7 +232,7 @@ impl ParsedNameConstraint {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ParsedMethodsConstraint(HashMap<String, TypeId>);
 
 impl ParsedMethodsConstraint {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"nested-functions","parentHead":"a9d92fd5da343b7ac6a9a94256cd1b2fdd77b23f","parentPull":161,"trunk":"main"}
```
-->
