### PR TITLE
Make backtrace a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ nom = "7.1.3"
 nom_locate = "4.1.0"
 walkdir = "2.3.2"
 indoc = "2.0.0"
+backtrace = "0.3"
 
 [toolchain]
 channel = "1.66.0"

--- a/rust/type_checker/errors/Cargo.toml
+++ b/rust/type_checker/errors/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backtrace = "0.3"
+backtrace.workspace = true


### PR DESCRIPTION
By using workspace dependencies, we can have a single version policy for all our 3rd-party dependencies.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"clippy","parentHead":"5143482e313713647958767834334206d35e77a7","parentPull":162,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"clippy","parentHead":"5143482e313713647958767834334206d35e77a7","parentPull":162,"trunk":"main"}
```
-->
