### PR TITLE
Test that all conditions in if statements must evaluate to #true or #false (Fixes B-251)

### DIFF
--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1190,6 +1190,15 @@ mod test {
     }
 
     #[test]
+    fn errors_if_conditional_is_not_a_boolean() {
+        let mut schema = TypeSchema::new();
+        schema.make_identifier_for_test("a").unwrap();
+        let expression = parse_test_expression("if #green do a");
+        let result = translate_parsed_expression_to_generic_expression(&mut schema, expression);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn errors_with_the_branches_have_different_types() {
         let mut schema = TypeSchema::new();
         let expression = parse_test_expression("if #true do 1 else \"2\"");

--- a/tests/js/invalid/if/empty-list-conditional.buri
+++ b/tests/js/invalid/if/empty-list-conditional.buri
@@ -1,0 +1,1 @@
+result = if [] do "hello"

--- a/tests/js/invalid/if/green-conditional.buri
+++ b/tests/js/invalid/if/green-conditional.buri
@@ -1,0 +1,1 @@
+result = if #green do "hello"

--- a/tests/js/invalid/if/list-conditional.buri
+++ b/tests/js/invalid/if/list-conditional.buri
@@ -1,0 +1,1 @@
+result = if [1, 2, 3] do "hello"

--- a/tests/js/invalid/if/none-conditional.buri
+++ b/tests/js/invalid/if/none-conditional.buri
@@ -1,0 +1,1 @@
+result = if #none do "hello"

--- a/tests/js/invalid/if/one-conditional.buri
+++ b/tests/js/invalid/if/one-conditional.buri
@@ -1,0 +1,1 @@
+result = if 1 do "hello"

--- a/tests/js/invalid/if/record-conditional.buri
+++ b/tests/js/invalid/if/record-conditional.buri
@@ -1,0 +1,1 @@
+result = if {} do "hello"

--- a/tests/js/invalid/if/some-conditional.buri
+++ b/tests/js/invalid/if/some-conditional.buri
@@ -1,0 +1,1 @@
+result = if #some(1) do "hello"

--- a/tests/js/invalid/if/string-conditional.buri
+++ b/tests/js/invalid/if/string-conditional.buri
@@ -1,0 +1,1 @@
+result = if "hello" do "hello"

--- a/tests/js/invalid/if/zero-conditional.buri
+++ b/tests/js/invalid/if/zero-conditional.buri
@@ -1,0 +1,1 @@
+result = if 0 do "hello"


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"indented-declarations","parentHead":"2d91a8e38154c31f46659ebdd24ebb9ec0663205","parentPull":165,"trunk":"main"}
```
-->
