### PR TITLE
Test that argument names cannot be shadowed (Fixes B-277)

### DIFF
--- a/tests/js/invalid/function/argument-shadowing.buri
+++ b/tests/js/invalid/function/argument-shadowing.buri
@@ -1,0 +1,4 @@
+a = 1
+
+-- argument names cannot shadow global names
+func = (a) => a


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"conditional-types","parentHead":"f445ba9e6e52294821b44417265bd4316bde3b00","parentPull":166,"trunk":"main"}
```
-->
