### PR TITLE
Add e2e tests for the logical operator order of operations (Fixes B-225)

### DIFF
--- a/rust/parser/src/binary_operator_expression.rs
+++ b/rust/parser/src/binary_operator_expression.rs
@@ -177,7 +177,8 @@ const fn order_of_operations(symbol: &BinaryOperatorSymbol) -> u8 {
         | BinaryOperatorSymbol::LessThanOrEqualTo
         | BinaryOperatorSymbol::GreaterThan
         | BinaryOperatorSymbol::GreaterThanOrEqualTo => 6,
-        BinaryOperatorSymbol::And | BinaryOperatorSymbol::Or => 7,
+        BinaryOperatorSymbol::And => 7,
+        BinaryOperatorSymbol::Or => 8,
     }
 }
 

--- a/tests/js/valid/logical-operators/order-of-operations.buri
+++ b/tests/js/valid/logical-operators/order-of-operations.buri
@@ -1,0 +1,107 @@
+-- and or
+
+@export
+trueAndTrueOrTrue = #true and #true or #true
+
+@export
+trueAndTrueOrFalse = #true and #true or #false
+
+@export
+trueAndFalseOrTrue = #true and #false or #true
+
+@export
+falseAndTrueOrTrue = #false and #true or #true
+
+@export
+falseAndFalseOrTrue = #false and #false or #true
+
+@export
+trueAndFalseOrFalse = #true and #false or #false
+
+@export
+falseAndTrueOrFalse = #false and #true or #false
+
+@export
+falseAndFalseOrFalse = #false and #false or #false
+
+-- or and
+
+@export
+trueOrTrueAndTrue = #true or #true and #true
+
+@export
+trueOrTrueAndFalse = #true or #true and #false
+
+@export
+trueOrFalseAndTrue = #true or #false and #true
+
+@export
+falseOrTrueAndTrue = #false or #true and #true
+
+@export
+falseOrFalseAndTrue = #false or #false and #true
+
+@export
+trueOrFalseAndFalse = #true or #false and #false
+
+@export
+falseOrTrueAndFalse = #false or #true and #false
+
+@export
+falseOrFalseAndFalse = #false or #false and #false
+
+-- not and
+
+@export
+notTrueAndTrue = not #true and #true
+
+@export
+notFalseAndTrue = not #false and #true
+
+@export
+notTrueAndFalse = not #true and #false
+
+@export
+notFalseAndFalse = not #false and #false
+
+-- not or
+
+@export
+notTrueOrTrue = not #true or #true
+
+@export
+notFalseOrTrue = not #false or #true
+
+@export
+notTrueOrFalse = not #true or #false
+
+@export
+notFalseOrFalse = not #false or #false
+
+-- or not
+
+@export
+trueOrNotTrue = #true or not #true
+
+@export
+trueOrNotFalse = #true or not #false
+
+@export
+falseOrNotTrue = #false or not #true
+
+@export
+falseOrNotFalse = #false or not #false
+
+-- and not
+
+@export
+trueAndNotTrue = #true and not #true
+
+@export
+trueAndNotFalse = #true and not #false
+
+@export
+falseAndNotTrue = #false and not #true
+
+@export
+falseAndNotFalse = #false and not #false

--- a/tests/js/valid/logical-operators/order-of-operations.test.js
+++ b/tests/js/valid/logical-operators/order-of-operations.test.js
@@ -1,0 +1,176 @@
+import {
+    falseAndFalseOrFalse,
+    falseAndFalseOrTrue,
+    falseAndNotFalse,
+    falseAndNotTrue,
+    falseAndTrueOrFalse,
+    falseAndTrueOrTrue,
+    falseOrFalseAndFalse,
+    falseOrFalseAndTrue,
+    falseOrNotFalse,
+    falseOrNotTrue,
+    falseOrTrueAndFalse,
+    falseOrTrueAndTrue,
+    notFalseAndFalse,
+    notFalseAndTrue,
+    notFalseOrFalse,
+    notFalseOrTrue,
+    notTrueAndFalse,
+    notTrueAndTrue,
+    notTrueOrFalse,
+    notTrueOrTrue,
+    trueAndFalseOrFalse,
+    trueAndFalseOrTrue,
+    trueAndNotFalse,
+    trueAndNotTrue,
+    trueAndTrueOrFalse,
+    trueAndTrueOrTrue,
+    trueOrFalseAndFalse,
+    trueOrFalseAndTrue,
+    trueOrNotFalse,
+    trueOrNotTrue,
+    trueOrTrueAndFalse,
+    trueOrTrueAndTrue,
+} from "@tests/js/valid/logical-operators/order-of-operations.mjs"
+import { describe, expect, it } from "bun:test"
+import { tag } from "../helpers"
+
+describe("and or", () => {
+    it("#true and #true or #true", () => {
+        expect(trueAndTrueOrTrue).toEqual(tag("true"))
+    })
+
+    it("#true and #true or #false", () => {
+        expect(trueAndTrueOrFalse).toEqual(tag("true"))
+    })
+
+    it("#true and #false or #true", () => {
+        expect(trueAndFalseOrTrue).toEqual(tag("true"))
+    })
+
+    it("#false and #true or #true", () => {
+        expect(falseAndTrueOrTrue).toEqual(tag("true"))
+    })
+
+    it("#false and #false or #true", () => {
+        expect(falseAndFalseOrTrue).toEqual(tag("true"))
+    })
+
+    it("#true and #false or #false", () => {
+        expect(trueAndFalseOrFalse).toEqual(tag("false"))
+    })
+
+    it("#false and #true or #false", () => {
+        expect(falseAndTrueOrFalse).toEqual(tag("false"))
+    })
+
+    it("#false and #false or #false", () => {
+        expect(falseAndFalseOrFalse).toEqual(tag("false"))
+    })
+})
+
+describe("or and", () => {
+    it("#true or #true and #true", () => {
+        expect(trueOrTrueAndTrue).toEqual(tag("true"))
+    })
+
+    it("#true or #true and #false", () => {
+        expect(trueOrTrueAndFalse).toEqual(tag("true"))
+    })
+
+    it("#true or #false and #true", () => {
+        expect(trueOrFalseAndTrue).toEqual(tag("true"))
+    })
+
+    it("#false or #true and #true", () => {
+        expect(falseOrTrueAndTrue).toEqual(tag("true"))
+    })
+
+    it("#false or #false and #true", () => {
+        expect(falseOrFalseAndTrue).toEqual(tag("false"))
+    })
+
+    it("#true or #false and #false", () => {
+        expect(trueOrFalseAndFalse).toEqual(tag("true"))
+    })
+
+    it("#false or #true and #false", () => {
+        expect(falseOrTrueAndFalse).toEqual(tag("false"))
+    })
+
+    it("#false or #false and #false", () => {
+        expect(falseOrFalseAndFalse).toEqual(tag("false"))
+    })
+})
+
+describe("not and", () => {
+    it("not #true and #true", () => {
+        expect(notTrueAndTrue).toEqual(tag("false"))
+    })
+
+    it("not #false and #true", () => {
+        expect(notFalseAndTrue).toEqual(tag("true"))
+    })
+
+    it("not #true and #false", () => {
+        expect(notTrueAndFalse).toEqual(tag("false"))
+    })
+
+    it("not #false and #false", () => {
+        expect(notFalseAndFalse).toEqual(tag("false"))
+    })
+})
+
+describe("not or", () => {
+    it("not #true or #true", () => {
+        expect(notTrueOrTrue).toEqual(tag("true"))
+    })
+
+    it("not #false or #true", () => {
+        expect(notFalseOrTrue).toEqual(tag("true"))
+    })
+
+    it("not #true or #false", () => {
+        expect(notTrueOrFalse).toEqual(tag("false"))
+    })
+
+    it("not #false or #false", () => {
+        expect(notFalseOrFalse).toEqual(tag("true"))
+    })
+})
+
+describe("and not", () => {
+    it("#true and not #true", () => {
+        expect(trueAndNotTrue).toEqual(tag("false"))
+    })
+
+    it("#false and not #true", () => {
+        expect(falseAndNotTrue).toEqual(tag("false"))
+    })
+
+    it("#true and not #false", () => {
+        expect(trueAndNotFalse).toEqual(tag("true"))
+    })
+
+    it("#false and not #false", () => {
+        expect(falseAndNotFalse).toEqual(tag("false"))
+    })
+})
+
+describe("or not", () => {
+    it("#true or not #true", () => {
+        expect(trueOrNotTrue).toEqual(tag("true"))
+    })
+
+    it("#false or not #true", () => {
+        expect(falseOrNotTrue).toEqual(tag("false"))
+    })
+
+    it("#true or not #false", () => {
+        expect(trueOrNotFalse).toEqual(tag("true"))
+    })
+
+    it("#false or not #false", () => {
+        expect(falseOrNotFalse).toEqual(tag("true"))
+    })
+})


### PR DESCRIPTION
Currently, `and` and `or` have equal precedence and are left associative. However, it looks like in many languages such as JavaScript, Roc, and Python, `and` has higher precedence than `or`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table

So in this PR, I updated the operator precedence to match the existing languages.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"function-scope","parentHead":"2b426fe880f611851a2187178dec6b110918e61a","parentPull":169,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"function-scope","parentHead":"2b426fe880f611851a2187178dec6b110918e61a","parentPull":169,"trunk":"main"}
```
-->
