### PR TITLE
Ensure Ints and Strs use the correct declaration type

### DIFF
--- a/rust/type_checker/translator/src/apply_constraints.rs
+++ b/rust/type_checker/translator/src/apply_constraints.rs
@@ -31,15 +31,6 @@ fn translate_top_level_type_declaration<'a>(
 
 pub fn apply_constraints(input: DocumentNode) -> Result<(GenericDocument, TypeSchema), String> {
     let mut schema = TypeSchema::new();
-    let mut variable_declarations: Vec<TopLevelDeclaration<GenericDeclarationExpression>> =
-        Vec::new();
-    variable_declarations.reserve_exact(input.value.variable_declarations.len());
-    for variable_declaration in input.value.variable_declarations {
-        variable_declarations.push(translate_top_level_variable_declaration(
-            &mut schema,
-            variable_declaration,
-        )?);
-    }
     let mut type_declarations: Vec<TopLevelDeclaration<GenericTypeDeclarationExpression>> =
         Vec::new();
     type_declarations.reserve_exact(input.value.type_declarations.len());
@@ -47,6 +38,15 @@ pub fn apply_constraints(input: DocumentNode) -> Result<(GenericDocument, TypeSc
         type_declarations.push(translate_top_level_type_declaration(
             &mut schema,
             type_declaration,
+        )?);
+    }
+    let mut variable_declarations: Vec<TopLevelDeclaration<GenericDeclarationExpression>> =
+        Vec::new();
+    variable_declarations.reserve_exact(input.value.variable_declarations.len());
+    for variable_declaration in input.value.variable_declarations {
+        variable_declarations.push(translate_top_level_variable_declaration(
+            &mut schema,
+            variable_declaration,
         )?);
     }
     Ok((

--- a/tests/js/invalid/integer/type-declaration.buri
+++ b/tests/js/invalid/integer/type-declaration.buri
@@ -1,0 +1,1 @@
+string: Str = 1

--- a/tests/js/invalid/string/type-identifier.buri
+++ b/tests/js/invalid/string/type-identifier.buri
@@ -1,0 +1,1 @@
+int: Int = "hello"


### PR DESCRIPTION
This PR ensures that if you specify the type of an integer or string, you must actually define the variable with the correct type.

One note is that in the bootstrapped compiler, we should probably change how declarations are parsed. Specifically, we separate out type declarations and normal declarations. In reality, we should interleave them to ensure all identifiers are used before they're defined.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"str-type","parentHead":"125e384c478f3bf07f69164c95591b9575739e5d","parentPull":172,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"str-type","parentHead":"125e384c478f3bf07f69164c95591b9575739e5d","parentPull":172,"trunk":"main"}
```
-->
