### PR TITLE
Can use record type annotations

### DIFF
--- a/rust/type_checker/types/src/constraints.rs
+++ b/rust/type_checker/types/src/constraints.rs
@@ -28,7 +28,7 @@ pub struct HasFieldConstraint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FieldAtMostConstraint {
+pub struct HasExactFieldsConstraint {
     pub fields: HashMap<String, TypeId>,
 }
 
@@ -57,7 +57,7 @@ pub enum Constraint {
     /// Constrain that a generic type is a tag union with at most a given set of tags.
     TagAtMost(TagAtMostConstraint),
     HasField(HasFieldConstraint),
-    FieldAtMost(FieldAtMostConstraint),
+    HasExactFields(HasExactFieldsConstraint),
     HasMethod(HasMethodConstraint),
     /// Constrain that a generic type is a function with a given return type.
     HasFunctionShape(HasFunctionShape),

--- a/tests/js/invalid/list/mismatched-type-3.buri
+++ b/tests/js/invalid/list/mismatched-type-3.buri
@@ -1,0 +1,1 @@
+words: [{ name: Str }] = [{ age: 21 }]

--- a/tests/js/invalid/list/mixed-types-2.buri
+++ b/tests/js/invalid/list/mixed-types-2.buri
@@ -1,0 +1,2 @@
+-- types are mixed
+mixed = [{ item: 1 }, { item: "2" }]

--- a/tests/js/invalid/record/mismatched-type-0.buri
+++ b/tests/js/invalid/record/mismatched-type-0.buri
@@ -1,0 +1,9 @@
+Person = {
+    name: Str,
+    age: Int,
+}
+
+jane: Person = {
+    name: "Jane",
+    age: "23",
+}

--- a/tests/js/invalid/record/mismatched-type-1.buri
+++ b/tests/js/invalid/record/mismatched-type-1.buri
@@ -1,0 +1,7 @@
+Person = {
+    name: #charlie | #jane,
+}
+
+jane: Person = {
+    name: "Jane",
+}

--- a/tests/js/invalid/record/mismatched-type-2.buri
+++ b/tests/js/invalid/record/mismatched-type-2.buri
@@ -1,0 +1,7 @@
+Data = {
+    data: [Str],
+}
+
+data: Data = {
+    data: [1, 2, 3],
+}

--- a/tests/js/invalid/record/mismatched-type-3.buri
+++ b/tests/js/invalid/record/mismatched-type-3.buri
@@ -1,0 +1,8 @@
+Data = {
+    data: Str,
+    other: Int,
+}
+
+data: Data = {
+    data: "hello",
+}

--- a/tests/js/invalid/record/mismatched-type-4.buri
+++ b/tests/js/invalid/record/mismatched-type-4.buri
@@ -1,0 +1,8 @@
+Data = {
+    data: Str,
+}
+
+data: Data = {
+    data: "hello",
+    other: 2,
+}

--- a/tests/js/valid/record/type-declaration.buri
+++ b/tests/js/valid/record/type-declaration.buri
@@ -1,0 +1,36 @@
+Person = {
+    name: Str,
+    age: Int,
+}
+john: Person = {
+    name: "John",
+    age: 42,
+}
+
+inlineDefinition: {
+    name: Str,
+    age: Int,
+} = {
+    name: "John",
+    age: 42,
+}
+
+Nested = {
+    person: Person,
+    roles: [Str],
+    gradeCount: {
+        a: Int,
+        b: Int,
+        c: Int,
+    },
+}
+
+nested: Nested = {
+    person: john,
+    roles: ["admin", "user"],
+    gradeCount: {
+        a: 1,
+        b: 2,
+        c: 3,
+    },
+}


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"list-type","parentHead":"5c5d78a50ecdfb43058b6d68362bdb1881e6bc11","parentPull":174,"trunk":"main"}
```
-->
