### PR TITLE
Test that the return value is properly inferred (Fixes B-303)

### DIFF
--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -263,6 +263,8 @@ fn translate_binary_operator<'a>(
                 &id_collection,
                 &translated_right_child,
             )?;
+            let function_type_id = get_generic_type_id(&translated_left_child);
+            schema.set_equal_to_function_result(type_id, function_type_id)?;
         }
         BinaryOperatorSymbol::MethodLookup => {
             translate_binary_operator_add_method_lookup_constraints(
@@ -1626,5 +1628,15 @@ mod test {
         let expression = parse_test_expression("int: MyInt = 1");
         let result = translate_parsed_expression_to_generic_expression(&mut schema, expression);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn checks_if_function_result_is_assigned_to_wrong_type() {
+        let mut schema = TypeSchema::new();
+        let expression = parse_test_expression("func: (Int) => Int = (a) => a");
+        translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
+        let expression = parse_test_expression("hello: Str = func(1)");
+        let result = translate_parsed_expression_to_generic_expression(&mut schema, expression);
+        assert!(result.is_err());
     }
 }

--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -209,6 +209,17 @@ impl CategoryConstraints {
             _ => (),
         }
     }
+
+    #[must_use]
+    pub const fn get_function_return_type(&self) -> Option<TypeId> {
+        match self {
+            Self::Function(FunctionConstraints {
+                return_type,
+                argument_types: _,
+            }) => Some(*return_type),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -407,6 +418,11 @@ impl ParsedConstraint {
                 }))
             }
         }
+    }
+
+    #[must_use]
+    pub const fn get_function_return_type(&self) -> Option<TypeId> {
+        self.category.get_function_return_type()
     }
 }
 

--- a/rust/type_checker/types/src/type_schema.rs
+++ b/rust/type_checker/types/src/type_schema.rs
@@ -133,6 +133,23 @@ impl TypeSchema {
             |parsed_constraint| parsed_constraint.to_concrete_type(self),
         )
     }
+    pub fn set_equal_to_function_result(
+        &mut self,
+        expression_type_id: TypeId,
+        function_type_id: TypeId,
+    ) -> Result<(), String> {
+        let function_type_canonical_id = self.get_canonical_id(function_type_id);
+        #[allow(clippy::option_if_let_else)] // Making this change violates the borrow checker.
+        match self.constraints.get(&function_type_canonical_id) {
+            Some(parsed_constraint) => parsed_constraint.get_function_return_type().map_or_else(
+                || Err(generate_backtrace_error("NotAFunction".to_owned())),
+                |return_type_id| {
+                    self.set_equal_to_canonical_type(return_type_id, expression_type_id)
+                },
+            ),
+            _ => Err(generate_backtrace_error("NotAFunction".to_owned())),
+        }
+    }
     #[must_use]
     pub fn get_canonical_id(&self, type_id: TypeId) -> TypeId {
         self.types.get_canonical_id(type_id)

--- a/tests/js/invalid/function/mismatched-types-5.buri
+++ b/tests/js/invalid/function/mismatched-types-5.buri
@@ -1,0 +1,2 @@
+func: (Int) => Int = (a) => a
+hello: Str = func(1)


### PR DESCRIPTION
Looks like we never added a constraint that a function application expression has the type of the function's return type. This PR adds that constraint.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
