### PR TITLE
Test that arguments are properly inferred from type annotations (Fixes B-302)

### DIFF
--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -220,6 +220,16 @@ impl CategoryConstraints {
             _ => None,
         }
     }
+
+    #[must_use]
+    pub fn get_function_argument_types(&self) -> Option<Vec<TypeId>> {
+        match self {
+            Self::Function(FunctionConstraints { argument_types, .. }) => {
+                Some(argument_types.clone())
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -423,6 +433,11 @@ impl ParsedConstraint {
     #[must_use]
     pub const fn get_function_return_type(&self) -> Option<TypeId> {
         self.category.get_function_return_type()
+    }
+
+    #[must_use]
+    pub fn get_function_argument_types(&self) -> Option<Vec<TypeId>> {
+        self.category.get_function_argument_types()
     }
 }
 

--- a/rust/type_checker/types/src/type_schema.rs
+++ b/rust/type_checker/types/src/type_schema.rs
@@ -151,6 +151,13 @@ impl TypeSchema {
         }
     }
     #[must_use]
+    pub fn get_function_argument_types(&self, function_type_id: TypeId) -> Option<Vec<TypeId>> {
+        let function_type_canonical_id = self.get_canonical_id(function_type_id);
+        self.constraints
+            .get(&function_type_canonical_id)
+            .and_then(ParsedConstraint::get_function_argument_types)
+    }
+    #[must_use]
     pub fn get_canonical_id(&self, type_id: TypeId) -> TypeId {
         self.types.get_canonical_id(type_id)
     }

--- a/tests/js/invalid/function/mismatched-types-6.buri
+++ b/tests/js/invalid/function/mismatched-types-6.buri
@@ -1,0 +1,2 @@
+Func = (Int) => Str
+func: Func = (a) => a

--- a/tests/js/invalid/function/mismatched-types-7.buri
+++ b/tests/js/invalid/function/mismatched-types-7.buri
@@ -1,0 +1,4 @@
+Primary = #red | #green | #blue
+Rainbow = #red | #orange | #yellow | #green | #blue | #purple
+
+isGreen: (Rainbow) => #true | #false = (a: Primary) => a == #green

--- a/tests/js/invalid/function/mismatched-types-8.buri
+++ b/tests/js/invalid/function/mismatched-types-8.buri
@@ -1,0 +1,5 @@
+Primary = #red | #green | #blue
+Rainbow = #red | #orange | #yellow | #green | #blue | #purple
+
+IsGreen = (Rainbow) => #true | #false
+isGreen: IsGreen = (a: Primary) => a == #green

--- a/tests/js/valid/functions/type-declarations.buri
+++ b/tests/js/valid/functions/type-declarations.buri
@@ -19,3 +19,11 @@ functionAsReturnValue = (a): Identity =>
     (b) => b
 
 inlineTypeDef: (Int) => Int = (a) => a
+
+Primary = #red | #green | #blue
+Rainbow = #red | #orange | #yellow | #green | #blue | #purple
+
+isBlue: (Primary) => #true | #false = (a: Rainbow) => a == #blue
+
+IsRed = (Primary) => #true | #false
+isRed: IsRed = (a: Rainbow) => a == #red


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
