### PR TITLE
Redesign blocks in Buri. Rewrite if parser to utilize new block style.

### DIFF
--- a/rust/parser/src/function.rs
+++ b/rust/parser/src/function.rs
@@ -208,7 +208,7 @@ mod test {
 
     #[test]
     fn function_body_can_be_block() {
-        let input = ParserInput::new("(x,y)=>\n    1 + 2\n    x - y\n");
+        let input = ParserInput::new("(x,y)=>\n    1 + 2\n    x - y");
         let result = function(ExpressionContext::new(), input);
         let (remainder, _) = result.unwrap();
         assert_eq!(remainder, "");
@@ -248,6 +248,6 @@ mod test {
         "});
         let result = function(ExpressionContext::new(), input);
         let (remainder, _) = result.unwrap();
-        assert_eq!(remainder, "");
+        assert_eq!(remainder, "\n");
     }
 }

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -44,13 +44,21 @@ pub use file::parse_buri_file;
 ///
 /// Panics if the input is not a valid expression.
 pub fn parse_test_expression(input: &str) -> ast::Expression {
-    use nom::{combinator::eof, sequence::terminated};
+    use crate::newline::newline;
+    use nom::{
+        combinator::{eof, map, opt},
+        sequence::tuple,
+    };
 
     let input = ast::ParserInput::new(input);
     #[allow(clippy::unwrap_used)] // because this should only be used in tests.
-    let (_, expression) = terminated(
-        expression(ExpressionContext::new().allow_newlines_in_expressions()),
-        eof,
+    let (_, expression) = map(
+        tuple((
+            expression(ExpressionContext::new().allow_newlines_in_expressions()),
+            opt(newline),
+            eof,
+        )),
+        |(expression, _, _)| expression,
     )(input)
     .unwrap();
     expression

--- a/rust/parser/src/variable_declaration.rs
+++ b/rust/parser/src/variable_declaration.rs
@@ -233,7 +233,7 @@ mod test {
         let input = ParserInput::new(input);
         let result = variable_declaration(ExpressionContext::new(), input);
         let (remainder, _) = result.unwrap();
-        assert_eq!(remainder, "bar = 3");
+        assert_eq!(remainder, "\nbar = 3");
     }
 
     #[test]
@@ -246,6 +246,6 @@ mod test {
         "});
         let result = variable_declaration(ExpressionContext::new(), input);
         let (remainder, _) = result.unwrap();
-        assert_eq!(remainder, "");
+        assert_eq!(remainder, "\n");
     }
 }


### PR DESCRIPTION
This PR serves as a backbone for fixing [B-295](https://linear.app/cambiata/issue/B-295).
A complete fix will come in a followup PR in this PR stack.

This PR introduces some breaking changes.
This are mostly trivial changes to how spaces and newlines are parsed in syntactically invalid inputs.

However, there is one significant breaking change. The following two snippets are now considered syntactically valid.

```
if x do y else
    z
```

```
if x do
    y
else z
```

Additionally, this PR makes the line parser obsolete and redundant. Fully removing the line parser will be left as a followup PR in this PR stack.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
