### PR TITLE
Add e2e test for tag types with a space between the identifier and contents (Fixes B-349(

### DIFF
--- a/tests/js/invalid/tag/malformed-type-0.buri
+++ b/tests/js/invalid/tag/malformed-type-0.buri
@@ -1,0 +1,1 @@
+Hello = #hello (Int)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-348","parentHead":"fa9a2e9fbbd0896a50a821a03520bed965d92b95","parentPull":244,"trunk":"b-322"}
```
-->
