### PR TITLE
Add e2e tests for invalid type identifiers (Fixes B-352)

### DIFF
--- a/tests/js/invalid/declarations/malformed-type-0.buri
+++ b/tests/js/invalid/declarations/malformed-type-0.buri
@@ -1,0 +1,2 @@
+hello = "hello"
+Hello = hello

--- a/tests/js/invalid/declarations/malformed-type-1.buri
+++ b/tests/js/invalid/declarations/malformed-type-1.buri
@@ -1,0 +1,1 @@
+_Hello = #hello

--- a/tests/js/invalid/declarations/malformed-type-2.buri
+++ b/tests/js/invalid/declarations/malformed-type-2.buri
@@ -1,0 +1,1 @@
+1Hello = #hello


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-351","parentHead":"5aabc7afddeaa24f96f0b725087685d6bc43ef4d","parentPull":247,"trunk":"b-322"}
```
-->
