### PR TITLE
Add simple programs to E2E tests

### DIFF
--- a/packages/std/prelude/integer.js
+++ b/packages/std/prelude/integer.js
@@ -4,24 +4,24 @@ Object.assign(Number.prototype, {
     },
 
     add(num) {
-        return new this.constructor(this.valueOf() + num.valueOf())
+        return this.constructor(this.valueOf() + num.valueOf())
     },
 
     subtract(num) {
-        return new this.constructor(this.valueOf() - num.valueOf())
+        return this.constructor(this.valueOf() - num.valueOf())
     },
 
     multiply(num) {
         let result = this.valueOf() * num.valueOf()
         if (result === -0) result = 0
-        return new this.constructor(result)
+        return this.constructor(result)
     },
 
     divide(num) {
         const result = this.valueOf() / num.valueOf()
         const truncated = Math.trunc(result)
-        if (truncated === -0) return new this.constructor(0)
-        return new this.constructor(truncated)
+        if (truncated === -0) return this.constructor(0)
+        return this.constructor(truncated)
     },
 
     // Using a custom modulo function because the built-in one is mathematically incorrect.
@@ -31,11 +31,11 @@ Object.assign(Number.prototype, {
         let n = num.valueOf()
         let result = ((m % n) + n) % n
         if (result === -0) result = 0
-        return new this.constructor(result)
+        return this.constructor(result)
     },
 
     power(num) {
-        return new this.constructor(this.valueOf() ** num.valueOf())
+        return this.constructor(this.valueOf() ** num.valueOf())
     },
 
     equals(num) {

--- a/tests/js/valid/simple_programs/fibonacci.buri
+++ b/tests/js/valid/simple_programs/fibonacci.buri
@@ -1,0 +1,6 @@
+@export
+fib = (n) =>
+    if n < 2 do
+        1
+    else
+        fib(n - 1) + fib(n - 2)

--- a/tests/js/valid/simple_programs/fibonacci.test.js
+++ b/tests/js/valid/simple_programs/fibonacci.test.js
@@ -1,0 +1,26 @@
+import { Bfib } from "@tests/js/valid/simple_programs/fibonacci.mjs"
+import { expect, it } from "bun:test"
+
+it("fib(0)", () => {
+    expect(Bfib(0)).toBe(1)
+})
+
+it("fib(1)", () => {
+    expect(Bfib(1)).toBe(1)
+})
+
+it("fib(2)", () => {
+    expect(Bfib(2)).toBe(2)
+})
+
+it("fib(3)", () => {
+    expect(Bfib(3)).toBe(3)
+})
+
+it("fib(4)", () => {
+    expect(Bfib(4)).toBe(5)
+})
+
+it("fib(5)", () => {
+    expect(Bfib(5)).toBe(8)
+})

--- a/tests/js/valid/simple_programs/fizzbuzz.buri
+++ b/tests/js/valid/simple_programs/fizzbuzz.buri
@@ -1,0 +1,5 @@
+@export
+fizzbuzz = (n) =>
+    firstWord = if n % 3 == 0 do "fizz" else ""
+    secondWord = if n % 5 == 0 do "buzz" else ""
+    firstWord ++ secondWord

--- a/tests/js/valid/simple_programs/fizzbuzz.test.js
+++ b/tests/js/valid/simple_programs/fizzbuzz.test.js
@@ -1,0 +1,66 @@
+import { Bfizzbuzz } from "@tests/js/valid/simple_programs/fizzbuzz.mjs"
+import { expect, it } from "bun:test"
+
+it("fizzbuzz(0)", () => {
+    expect(Bfizzbuzz(0)).toBe("fizzbuzz")
+})
+
+it("fizzbuzz(1)", () => {
+    expect(Bfizzbuzz(1)).toBe("")
+})
+
+it("fizzbuzz(2)", () => {
+    expect(Bfizzbuzz(2)).toBe("")
+})
+
+it("fizzbuzz(3)", () => {
+    expect(Bfizzbuzz(3)).toBe("fizz")
+})
+
+it("fizzbuzz(4)", () => {
+    expect(Bfizzbuzz(4)).toBe("")
+})
+
+it("fizzbuzz(5)", () => {
+    expect(Bfizzbuzz(5)).toBe("buzz")
+})
+
+it("fizzbuzz(6)", () => {
+    expect(Bfizzbuzz(6)).toBe("fizz")
+})
+
+it("fizzbuzz(7)", () => {
+    expect(Bfizzbuzz(7)).toBe("")
+})
+
+it("fizzbuzz(8)", () => {
+    expect(Bfizzbuzz(8)).toBe("")
+})
+
+it("fizzbuzz(9)", () => {
+    expect(Bfizzbuzz(9)).toBe("fizz")
+})
+
+it("fizzbuzz(10)", () => {
+    expect(Bfizzbuzz(10)).toBe("buzz")
+})
+
+it("fizzbuzz(11)", () => {
+    expect(Bfizzbuzz(11)).toBe("")
+})
+
+it("fizzbuzz(12)", () => {
+    expect(Bfizzbuzz(12)).toBe("fizz")
+})
+
+it("fizzbuzz(13)", () => {
+    expect(Bfizzbuzz(13)).toBe("")
+})
+
+it("fizzbuzz(14)", () => {
+    expect(Bfizzbuzz(14)).toBe("")
+})
+
+it("fizzbuzz(15)", () => {
+    expect(Bfizzbuzz(15)).toBe("fizzbuzz")
+})

--- a/tests/js/valid/simple_programs/hello_world.buri
+++ b/tests/js/valid/simple_programs/hello_world.buri
@@ -1,0 +1,3 @@
+@export
+helloWorld = () =>
+    "Hello World!"

--- a/tests/js/valid/simple_programs/hello_world.test.js
+++ b/tests/js/valid/simple_programs/hello_world.test.js
@@ -1,0 +1,6 @@
+import { BhelloWorld } from "@tests/js/valid/simple_programs/hello_world.mjs"
+import { expect, it } from "bun:test"
+
+it("hello world", () => {
+    expect(BhelloWorld()).toEqual("Hello World!")
+})

--- a/tests/js/valid/simple_programs/is_prime.buri
+++ b/tests/js/valid/simple_programs/is_prime.buri
@@ -1,0 +1,14 @@
+aOrLargerDividesB = (a, b) =>
+    if a >= b do
+        #false
+    else if b % a == 0 do
+        #true
+    else
+        aOrLargerDividesB(a + 1, b)
+
+@export
+isPrime = (n) =>
+    if n < 2 do
+        #false
+    else
+        not aOrLargerDividesB(2, n)

--- a/tests/js/valid/simple_programs/is_prime.test.js
+++ b/tests/js/valid/simple_programs/is_prime.test.js
@@ -1,0 +1,55 @@
+import { BisPrime } from "@tests/js/valid/simple_programs/is_prime.mjs"
+import { expect, it } from "bun:test"
+import { tag } from "../helpers"
+
+it("isPrime(0)", () => {
+    expect(BisPrime(0)).toEqual(tag("false"))
+})
+
+it("isPrime(1)", () => {
+    expect(BisPrime(1)).toEqual(tag("false"))
+})
+
+it("isPrime(2)", () => {
+    expect(BisPrime(2)).toEqual(tag("true"))
+})
+
+it("isPrime(3)", () => {
+    expect(BisPrime(3)).toEqual(tag("true"))
+})
+
+it("isPrime(4)", () => {
+    expect(BisPrime(4)).toEqual(tag("false"))
+})
+
+it("isPrime(5)", () => {
+    expect(BisPrime(5)).toEqual(tag("true"))
+})
+
+it("isPrime(6)", () => {
+    expect(BisPrime(6)).toEqual(tag("false"))
+})
+
+it("isPrime(7)", () => {
+    expect(BisPrime(7)).toEqual(tag("true"))
+})
+
+it("isPrime(8)", () => {
+    expect(BisPrime(8)).toEqual(tag("false"))
+})
+
+it("isPrime(9)", () => {
+    expect(BisPrime(9)).toEqual(tag("false"))
+})
+
+it("isPrime(10)", () => {
+    expect(BisPrime(10)).toEqual(tag("false"))
+})
+
+it("isPrime(11)", () => {
+    expect(BisPrime(11)).toEqual(tag("true"))
+})
+
+it("isPrime(12)", () => {
+    expect(BisPrime(12)).toEqual(tag("false"))
+})


### PR DESCRIPTION
Test that we can actually write coherent programs in Buri.

Fix a bug in JS prelude.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
