### PR TITLE
Add types to facilitate When Statement type checking

### DIFF
--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -167,6 +167,26 @@ pub struct UnaryOperatorValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhenCaseArgumentValue<'a> {
+    pub identifier: IdentifierNode<'a>,
+    pub type_expression: Option<TypeExpression<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhenCase<'a> {
+    pub case_name: TagIdentifierNode<'a>,
+    pub case_arguments: Vec<WhenCaseArgumentValue<'a>>,
+    pub expression: Expression<'a>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhenValue<'a> {
+    pub condition: Box<Expression<'a>>,
+    pub cases: Vec<WhenCase<'a>>,
+    pub default_case: Option<Box<Expression<'a>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclarationValue<'a> {
     pub identifier: IdentifierNode<'a>,
     pub type_expression: Option<TypeExpression<'a>>,
@@ -199,6 +219,7 @@ pub type TagTypeNode<'a> = ParsedNode<'a, TagTypeValue<'a>>;
 pub type TypeIdentifierNode<'a> = ParsedNode<'a, String>;
 pub type TypeDeclarationNode<'a> = ParsedNode<'a, TypeDeclarationValue<'a>>;
 pub type UnaryOperatorNode<'a> = ParsedNode<'a, UnaryOperatorValue<'a>>;
+pub type WhenNode<'a> = ParsedNode<'a, WhenValue<'a>>;
 pub type DeclarationNode<'a> = ParsedNode<'a, DeclarationValue<'a>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -239,6 +239,7 @@ pub enum Expression<'a> {
     Tag(TagNode<'a>),
     TypeDeclaration(TypeDeclarationNode<'a>),
     UnaryOperator(UnaryOperatorNode<'a>),
+    When(WhenNode<'a>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -51,6 +51,7 @@ fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::TypeDeclaration(_) | ConcreteExpression::TypeIdentifier(_) => {
             String::new()
         }
+        ConcreteExpression::When(_) => todo!(),
     }
 }
 

--- a/rust/parser/src/binary_operator_or_if.rs
+++ b/rust/parser/src/binary_operator_or_if.rs
@@ -1,6 +1,6 @@
 use crate::{
     binary_operator_expression::binary_operator_expression, if_statement::if_statement,
-    ExpressionContext,
+    when_statement::when_statement, ExpressionContext,
 };
 use ast::Expression;
 use ast::{IResult, ParserInput};
@@ -12,5 +12,6 @@ pub fn binary_operator_or_if<'a>(
     alt((
         binary_operator_expression(context),
         map(if_statement(context), Expression::If),
+        map(when_statement(context), Expression::When),
     ))
 }

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -32,6 +32,7 @@ mod type_expression;
 mod type_identifier;
 mod unary_operator;
 mod variable_declaration;
+mod when_statement;
 
 use binary_operator_or_if::binary_operator_or_if as expression;
 use expression_context::ExpressionContext;

--- a/rust/parser/src/when_statement.rs
+++ b/rust/parser/src/when_statement.rs
@@ -137,37 +137,39 @@ fn when_default_case<'a>(
 pub fn when_statement<'a>(
     context: ExpressionContext,
 ) -> impl FnMut(ParserInput<'a>) -> IResult<'a, WhenNode<'a>> {
-    verify(
-        map(
-            consumed(tuple((
-                when_condition(context),
-                tuple((
-                    separated_list1(newline, when_case(context.increment_indentation())),
-                    opt(preceded(
-                        newline,
-                        when_default_case(context.increment_indentation()),
+    move |input| {
+        verify(
+            map(
+                consumed(tuple((
+                    when_condition(context),
+                    tuple((
+                        separated_list1(newline, when_case(context.increment_indentation())),
+                        opt(preceded(
+                            newline,
+                            when_default_case(context.increment_indentation()),
+                        )),
                     )),
-                )),
-            ))),
-            |(source, (condition, (cases, default_case)))| WhenNode {
-                source,
-                value: WhenValue {
-                    condition: Box::new(condition),
-                    cases,
-                    default_case: default_case.map(Box::new),
+                ))),
+                |(source, (condition, (cases, default_case)))| WhenNode {
+                    source,
+                    value: WhenValue {
+                        condition: Box::new(condition),
+                        cases,
+                        default_case: default_case.map(Box::new),
+                    },
                 },
-            },
-        ),
-        |node| {
-            let mut case_name = HashSet::new();
-            for case in &node.value.cases {
-                if !case_name.insert(case.case_name.value.clone()) {
-                    return false;
+            ),
+            |node| {
+                let mut case_name = HashSet::new();
+                for case in &node.value.cases {
+                    if !case_name.insert(case.case_name.value.clone()) {
+                        return false;
+                    }
                 }
-            }
-            true
-        },
-    )
+                true
+            },
+        )(input)
+    }
 }
 
 #[cfg(test)]

--- a/rust/parser/src/when_statement.rs
+++ b/rust/parser/src/when_statement.rs
@@ -1,0 +1,377 @@
+use crate::{
+    block::block, expression, identifier::identifier, indent::indent_exact,
+    intra_expression_whitespace::intra_expression_whitespace, newline::newline,
+    tag_identifier::tag_identifier, type_expression::type_expression, ExpressionContext,
+};
+use ast::{Expression, IResult, ParserInput, WhenCase, WhenCaseArgumentValue, WhenNode, WhenValue};
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{space0, space1},
+    combinator::{consumed, map, opt, success, verify},
+    multi::{separated_list0, separated_list1},
+    sequence::{delimited, preceded, tuple},
+};
+use std::collections::HashSet;
+
+fn when_condition<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, Expression<'a>> {
+    delimited(
+        tuple((tag("when"), space1)),
+        expression(context),
+        tuple((space1, tag("is"), newline)),
+    )
+}
+
+fn case_argument<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, WhenCaseArgumentValue<'a>> {
+    map(
+        tuple((
+            identifier,
+            opt(preceded(
+                tuple((
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                    tag(":"),
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                )),
+                type_expression,
+            )),
+        )),
+        |(identifier, type_expression)| WhenCaseArgumentValue {
+            identifier,
+            type_expression,
+        },
+    )
+}
+
+fn case_arguments_vec<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, Vec<WhenCaseArgumentValue<'a>>> {
+    alt((
+        delimited(
+            tuple((
+                tag("("),
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+            )),
+            separated_list0(
+                tuple((
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                    tag(","),
+                    opt(intra_expression_whitespace(
+                        context.allow_newlines_in_expressions(),
+                    )),
+                )),
+                case_argument(context),
+            ),
+            tuple((
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+                opt(tag(",")),
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+                tag(")"),
+            )),
+        ),
+        success(vec![]),
+    ))
+}
+
+fn case_expression<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, Expression<'a>> {
+    alt((
+        delimited(space1, expression(context), space0),
+        preceded(
+            tuple((space0, newline)),
+            map(block(context.increment_indentation()), Expression::Block),
+        ),
+    ))
+}
+
+fn when_case<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, WhenCase<'a>> {
+    map(
+        tuple((
+            indent_exact(context.indentation),
+            tag_identifier,
+            case_arguments_vec(context),
+            space1,
+            tag("do"),
+            case_expression(context),
+        )),
+        |(_, case_name, case_arguments, _, _, expression)| WhenCase {
+            case_name,
+            case_arguments,
+            expression,
+        },
+    )
+}
+
+fn when_default_case<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, Expression<'a>> {
+    preceded(
+        tuple((
+            indent_exact(context.indentation),
+            tag("_"),
+            space1,
+            tag("do"),
+        )),
+        case_expression(context),
+    )
+}
+
+pub fn when_statement<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, WhenNode<'a>> {
+    verify(
+        map(
+            consumed(tuple((
+                when_condition(context),
+                tuple((
+                    separated_list1(newline, when_case(context.increment_indentation())),
+                    opt(preceded(
+                        newline,
+                        when_default_case(context.increment_indentation()),
+                    )),
+                )),
+            ))),
+            |(source, (condition, (cases, default_case)))| WhenNode {
+                source,
+                value: WhenValue {
+                    condition: Box::new(condition),
+                    cases,
+                    default_case: default_case.map(Box::new),
+                },
+            },
+        ),
+        |node| {
+            let mut case_name = HashSet::new();
+            for case in &node.value.cases {
+                if !case_name.insert(case.case_name.value.clone()) {
+                    return false;
+                }
+            }
+            true
+        },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_string_is_not_when_statement() {
+        let input = ParserInput::new("");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn when_keyword_is_not_when_statement() {
+        let input = ParserInput::new("when");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn when_keyword_with_expression_and_is_keyword_is_not_when_statement() {
+        let input = ParserInput::new("when x is");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn one_simple_case_parses() {
+        let input = ParserInput::new("when x is\n    #red do 1");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn two_simple_cases_parse() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn parse_a_default_case() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    _ do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn stop_parsing_after_default_case() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    _ do 2\n    #blue do 3");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "\n    #blue do 3");
+    }
+
+    #[test]
+    fn error_on_only_default_case() {
+        let input = ParserInput::new("when x is\n    _ do 1");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allow_only_one_default_case() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    _ do 2\n    _ do 3");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "\n    _ do 3");
+    }
+
+    #[test]
+    fn missing_when_keyword_errors() {
+        let input = ParserInput::new("x is\n    #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_is_keyword_errors() {
+        let input = ParserInput::new("when x\n    #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_do_keyword_errors() {
+        let input = ParserInput::new("when x is\n    #red 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_expression_errors() {
+        let input = ParserInput::new("when x is\n    #red do\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn newline_after_when_keyword_errors() {
+        let input = ParserInput::new("when\nx is\n    #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_newline_after_is_keyword_errors() {
+        let input = ParserInput::new("when x is 1 #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_newline_after_case_does_not_consume_following_cases() {
+        let input = ParserInput::new("when x is\n    #red do 1    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "#blue do 2");
+    }
+
+    #[test]
+    fn condition_can_be_tag_literal() {
+        let input = ParserInput::new("when #red is\n    #red do 1\n    #blue do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn cases_can_be_blocks() {
+        let input = ParserInput::new("when x is\n    #red do\n        1\n    #blue do\n        2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn cases_can_be_multiline_blocks() {
+        let input = ParserInput::new(
+            "when x is\n    #red do\n        1\n        2\n    #blue do\n        3\n        4",
+        );
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn default_case_can_be_block() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    _ do\n        2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn cases_can_have_payloads() {
+        let input = ParserInput::new("when x is\n    #red(value) do 1\n    #blue(value) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn cases_can_have_payloads_with_multiple_arguments() {
+        let input = ParserInput::new("when x is\n    #red(a, b) do 1\n    #blue(c, d) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn cases_can_have_payloads_with_different_numbers_of_arguments() {
+        let input = ParserInput::new("when x is\n    #red(a, b) do 1\n    #blue(c) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn simple_tags_can_be_mixed_with_tags_with_payloads() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    #blue(value) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn default_case_cannot_have_a_payload() {
+        let input = ParserInput::new("when x is\n    #red do 1\n    _(value) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "\n    _(value) do 2");
+    }
+
+    #[test]
+    fn payload_can_have_an_explicit_type_annotation() {
+        let input =
+            ParserInput::new("when x is\n    #red(value: Int) do 1\n    #blue(value: Int) do 2");
+        let result = when_statement(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+}

--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1102,6 +1102,7 @@ pub fn translate_parsed_expression_to_generic_expression<'a>(
         Expression::UnaryOperator(node) => translate_unary_operator(schema, node)
             .map(Box::new)
             .map(GenericExpression::UnaryOperator),
+        Expression::When(_) => todo!(),
     }
 }
 

--- a/rust/type_checker/types/src/generic_nodes.rs
+++ b/rust/type_checker/types/src/generic_nodes.rs
@@ -6,7 +6,7 @@ use typed_ast::{
     TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
     TypedListExpression, TypedRecordAssignmentExpression, TypedRecordExpression,
     TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclarationExpression,
-    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
+    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression, TypedWhenExpression,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,6 +38,7 @@ pub type GenericTypeDeclarationExpression<'a> =
 pub type GenericTypeIdentifierExpression<'a> =
     TypedTypeIdentifierExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
+pub type GenericWhenExpression<'a> = TypedWhenExpression<GenericSourcedType<'a>>;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
 
@@ -70,5 +71,6 @@ pub const fn get_generic_type_id(input: &GenericExpression) -> TypeId {
         GenericExpression::TypeDeclaration(node) => node.expression_type.type_id,
         GenericExpression::TypeIdentifier(node) => node.expression_type.type_id,
         GenericExpression::UnaryOperator(node) => node.expression_type.type_id,
+        GenericExpression::When(node) => node.expression_type.type_id,
     }
 }

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -5,6 +5,7 @@ use crate::{
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
     TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
+    TypedWhenExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -23,6 +24,7 @@ pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
 pub type ConcreteTypeDeclarationExpression = TypedTypeDeclarationExpression<ConcreteType>;
 pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
+pub type ConcreteWhenExpression = TypedWhenExpression<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -110,6 +110,21 @@ pub struct TypedUnaryOperatorExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedWhenCase<T> {
+    pub expression_type: T,
+    /// case_name == None indicates the default case
+    pub case_name: Option<TypedIdentifierExpression<T>>,
+    pub case_arguments: Vec<TypedIdentifierExpression<T>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedWhenExpression<T> {
+    pub expression_type: T,
+    pub condition: TypedExpression<T>,
+    pub cases: Vec<TypedWhenCase<T>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedExpression<T> {
     BinaryOperator(Box<TypedBinaryOperatorExpression<T>>),
     Block(Box<TypedBlockExpression<T>>),
@@ -128,6 +143,7 @@ pub enum TypedExpression<T> {
     TypeDeclaration(Box<TypedTypeDeclarationExpression<T>>),
     TypeIdentifier(Box<TypedTypeIdentifierExpression<T>>),
     UnaryOperator(Box<TypedUnaryOperatorExpression<T>>),
+    When(Box<TypedWhenExpression<T>>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"incorporate-when-parser","parentHead":"14ef2ef1ba7189027049d49d993e454c2c98ecd5","parentPull":262,"trunk":"main"}
```
-->
