### PR TITLE
Add when statements to type checker and resolver

### DIFF
--- a/rust/parser/src/is_keyword.rs
+++ b/rust/parser/src/is_keyword.rs
@@ -1,5 +1,5 @@
 pub fn is_keyword(value: &str) -> bool {
-    matches!(value, "if" | "do" | "else" | "and" | "or")
+    matches!(value, "if" | "when" | "do" | "else" | "and" | "or")
 }
 
 #[cfg(test)]

--- a/rust/type_checker/types/src/generic_nodes.rs
+++ b/rust/type_checker/types/src/generic_nodes.rs
@@ -6,7 +6,8 @@ use typed_ast::{
     TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
     TypedListExpression, TypedRecordAssignmentExpression, TypedRecordExpression,
     TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclarationExpression,
-    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression, TypedWhenExpression,
+    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression, TypedWhenCase, TypedWhenCaseName,
+    TypedWhenExpression,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,6 +40,8 @@ pub type GenericTypeIdentifierExpression<'a> =
     TypedTypeIdentifierExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
 pub type GenericWhenExpression<'a> = TypedWhenExpression<GenericSourcedType<'a>>;
+pub type GenericWhenCase<'a> = TypedWhenCase<GenericSourcedType<'a>>;
+pub type GenericWhenCaseName<'a> = TypedWhenCaseName;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
 

--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -246,6 +246,20 @@ impl CategoryConstraints {
             _ => None,
         }
     }
+
+    pub fn get_tag_content_types(&self, tag_name: &String) -> Result<Vec<TypeId>, String> {
+        match self {
+            Self::TagGroup(tag_group) => match tag_group {
+                TagGroupConstraints::ClosedTags(tags) | TagGroupConstraints::OpenTags(tags) => {
+                    tags.get(tag_name).map_or_else(
+                        || Err(format!("Tag {tag_name} not found")),
+                        |types| Ok(types.clone()),
+                    )
+                }
+            },
+            _ => Err(format!("Expected tag group, got {self:?}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -518,6 +532,10 @@ impl ParsedConstraint {
     ) -> Result<Option<TypeId>, String> {
         self.methods
             .get_same_method_type(schema, method_name, method_type, checked_types)
+    }
+
+    pub fn get_tag_content_types(&self, tag_name: &String) -> Result<Vec<TypeId>, String> {
+        self.category.get_tag_content_types(tag_name)
     }
 }
 

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -5,7 +5,7 @@ use crate::{
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
     TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
-    TypedWhenExpression,
+    TypedWhenCase, TypedWhenExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -25,6 +25,7 @@ pub type ConcreteTypeDeclarationExpression = TypedTypeDeclarationExpression<Conc
 pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 pub type ConcreteWhenExpression = TypedWhenExpression<ConcreteType>;
+pub type ConcreteWhenCase = TypedWhenCase<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -110,10 +110,16 @@ pub struct TypedUnaryOperatorExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypedWhenCaseName {
+    Name(String),
+    DefaultCase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedWhenCase<T> {
     pub expression_type: T,
     /// case_name == None indicates the default case
-    pub case_name: Option<TypedIdentifierExpression<T>>,
+    pub case_name: TypedWhenCaseName,
     pub case_arguments: Vec<TypedIdentifierExpression<T>>,
 }
 

--- a/tests/js/invalid/when/mismatched-types-0.buri
+++ b/tests/js/invalid/when/mismatched-types-0.buri
@@ -1,0 +1,4 @@
+x: #red | #green = #red
+result = when x is
+    #red do 1
+    #green do "hello"

--- a/tests/js/invalid/when/mismatched-types-1.buri
+++ b/tests/js/invalid/when/mismatched-types-1.buri
@@ -1,0 +1,4 @@
+x: #red | #green = #red
+result = when x is
+    #red do 1
+    _ do "hello"

--- a/tests/js/invalid/when/mismatched-types-2.buri
+++ b/tests/js/invalid/when/mismatched-types-2.buri
@@ -1,0 +1,3 @@
+blue = #blue
+result = when blue is
+    #red do 1

--- a/tests/js/invalid/when/mismatched-types-3.buri
+++ b/tests/js/invalid/when/mismatched-types-3.buri
@@ -1,0 +1,2 @@
+result = when #rgb(0, 0, 0) is
+    #rgb do 1

--- a/tests/js/invalid/when/mismatched-types-4.buri
+++ b/tests/js/invalid/when/mismatched-types-4.buri
@@ -1,0 +1,2 @@
+result = when #rgb(0, 0, 0) is
+    #rgb(red, green, blue) do red == "0"


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
