### PR TITLE
Add when statements to JS backend (Fixes B-381, B-382)

### DIFF
--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -11,6 +11,7 @@ mod record_assignment;
 mod tag;
 mod unary_operator;
 mod variable_name_mangling;
+mod when;
 
 use crate::{
     identifier::print_identifier,
@@ -20,6 +21,8 @@ use typed_ast::ConcreteExpression;
 
 pub use declaration::print_declaration;
 pub use variable_name_mangling::mangle_variable_name;
+
+use self::when::print_when;
 
 fn print_expression(expression: &ConcreteExpression) -> String {
     match expression {
@@ -51,7 +54,7 @@ fn print_expression(expression: &ConcreteExpression) -> String {
         ConcreteExpression::TypeDeclaration(_) | ConcreteExpression::TypeIdentifier(_) => {
             String::new()
         }
-        ConcreteExpression::When(_) => todo!(),
+        ConcreteExpression::When(when) => print_when(when),
     }
 }
 

--- a/rust/js_backend/src/expression/when.rs
+++ b/rust/js_backend/src/expression/when.rs
@@ -1,0 +1,49 @@
+use super::print_expression;
+use crate::expression::mangle_variable_name;
+use typed_ast::{ConcreteWhenCaseName, ConcreteWhenExpression};
+
+pub fn print_when(when: &ConcreteWhenExpression) -> String {
+    let printed_when_condition = print_expression(&when.condition);
+    print_when_case(when, &printed_when_condition, 0)
+}
+
+fn print_when_case(
+    when: &ConcreteWhenExpression,
+    printed_when_condition: &String,
+    index: usize,
+) -> String {
+    when.cases.get(index).map_or_else(
+        || String::from("0"),
+        |case| {
+            let mut result = String::new();
+            result.push('(');
+            match &case.case_name {
+                ConcreteWhenCaseName::Name(name) => {
+                    result.push_str(&format!(
+                        "{}[0]==\"{}\"",
+                        printed_when_condition.clone(),
+                        name
+                    ));
+                }
+                ConcreteWhenCaseName::DefaultCase => result.push_str("true"),
+            };
+            result.push('?');
+            result.push_str("(()=>{");
+            for (index, argument) in case.case_arguments.iter().enumerate() {
+                result.push_str(&format!(
+                    "let {}={}[{}];",
+                    mangle_variable_name(&argument.name),
+                    printed_when_condition.clone(),
+                    index + 1
+                ));
+            }
+            result.push_str("return ");
+            result.push_str(&print_expression(&case.case_expression));
+            result.push_str("})()");
+            result.push(':');
+            result.push_str(&print_when_case(when, printed_when_condition, index + 1));
+            result.push(')');
+            result
+        },
+    )
+}

--- a/rust/parser/src/is_keyword.rs
+++ b/rust/parser/src/is_keyword.rs
@@ -1,5 +1,5 @@
 pub fn is_keyword(value: &str) -> bool {
-    matches!(value, "if" | "do" | "else" | "and" | "or")
+    matches!(value, "if" | "when" | "do" | "else" | "and" | "or")
 }
 
 #[cfg(test)]

--- a/rust/type_checker/resolver/src/resolve_concrete_types.rs
+++ b/rust/type_checker/resolver/src/resolve_concrete_types.rs
@@ -284,6 +284,7 @@ fn resolve_when(
                     .into_iter()
                     .map(|argument| resolve_identifier(simplified_schema, argument))
                     .collect(),
+                case_expression: resolve_expression(simplified_schema, case.case_expression),
             })
             .collect(),
     }))

--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1071,6 +1071,7 @@ fn translate_when_expression<'a>(
         schema.scope.start_sub_scope();
 
         let mut tag_content_types = Vec::new();
+        let mut case_arguments = Vec::new();
         let tag_name = case.case_name.value;
         for argument in case.case_arguments {
             let name_type_id = schema.make_id();
@@ -1078,6 +1079,14 @@ fn translate_when_expression<'a>(
                 .scope
                 .declare_identifier(argument.identifier.value.name.clone(), name_type_id)?;
             tag_content_types.push(name_type_id);
+            case_arguments.push(GenericIdentifierExpression {
+                expression_type: GenericSourcedType {
+                    type_id: name_type_id,
+                    source_of_type: expression.source.clone(),
+                },
+                name: argument.identifier.value.name,
+                is_disregarded: argument.identifier.value.is_disregarded,
+            });
         }
         schema.set_equal_to_tag_contents(condition_type, &tag_name, &tag_content_types)?;
 
@@ -1107,11 +1116,12 @@ fn translate_when_expression<'a>(
 
         cases.push(GenericWhenCase {
             case_name: GenericWhenCaseName::Name(tag_name),
-            case_arguments: vec![],
+            case_arguments,
             expression_type: GenericSourcedType {
                 type_id: case_expression_type,
                 source_of_type: expression.source.clone(),
             },
+            case_expression: translated_expression,
         });
     }
 
@@ -1142,6 +1152,7 @@ fn translate_when_expression<'a>(
                 type_id: case_expression_type,
                 source_of_type: expression.source.clone(),
             },
+            case_expression: translated_expression,
         });
     }
 

--- a/rust/type_checker/types/src/generic_nodes.rs
+++ b/rust/type_checker/types/src/generic_nodes.rs
@@ -6,7 +6,8 @@ use typed_ast::{
     TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
     TypedListExpression, TypedRecordAssignmentExpression, TypedRecordExpression,
     TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclarationExpression,
-    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression, TypedWhenExpression,
+    TypedTypeIdentifierExpression, TypedUnaryOperatorExpression, TypedWhenCase, TypedWhenCaseName,
+    TypedWhenExpression,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,6 +40,8 @@ pub type GenericTypeIdentifierExpression<'a> =
     TypedTypeIdentifierExpression<GenericSourcedType<'a>>;
 pub type GenericUnaryOperatorExpression<'a> = TypedUnaryOperatorExpression<GenericSourcedType<'a>>;
 pub type GenericWhenExpression<'a> = TypedWhenExpression<GenericSourcedType<'a>>;
+pub type GenericWhenCase<'a> = TypedWhenCase<GenericSourcedType<'a>>;
+pub type GenericWhenCaseName<'a> = TypedWhenCaseName;
 
 pub type GenericExpression<'a> = TypedExpression<GenericSourcedType<'a>>;
 

--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -246,6 +246,20 @@ impl CategoryConstraints {
             _ => None,
         }
     }
+
+    pub fn get_tag_content_types(&self, tag_name: &String) -> Result<Vec<TypeId>, String> {
+        match self {
+            Self::TagGroup(tag_group) => match tag_group {
+                TagGroupConstraints::ClosedTags(tags) | TagGroupConstraints::OpenTags(tags) => {
+                    tags.get(tag_name).map_or_else(
+                        || Err(format!("Tag {tag_name} not found")),
+                        |types| Ok(types.clone()),
+                    )
+                }
+            },
+            _ => Err(format!("Expected tag group, got {self:?}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -518,6 +532,10 @@ impl ParsedConstraint {
     ) -> Result<Option<TypeId>, String> {
         self.methods
             .get_same_method_type(schema, method_name, method_type, checked_types)
+    }
+
+    pub fn get_tag_content_types(&self, tag_name: &String) -> Result<Vec<TypeId>, String> {
+        self.category.get_tag_content_types(tag_name)
     }
 }
 

--- a/rust/type_checker/types/src/type_schema.rs
+++ b/rust/type_checker/types/src/type_schema.rs
@@ -294,9 +294,7 @@ impl TypeSchema {
                 }
                 Ok(())
             }
-            _ => Err(generate_backtrace_error(format!(
-                "NoConstraintForType: {tag_type_id}"
-            ))),
+            _ => Ok(()),
         }
     }
 

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -5,7 +5,7 @@ use crate::{
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
     TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
-    TypedWhenExpression,
+    TypedWhenCase, TypedWhenExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -25,6 +25,7 @@ pub type ConcreteTypeDeclarationExpression = TypedTypeDeclarationExpression<Conc
 pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 pub type ConcreteWhenExpression = TypedWhenExpression<ConcreteType>;
+pub type ConcreteWhenCase = TypedWhenCase<ConcreteType>;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
 

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -5,7 +5,7 @@ use crate::{
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
     TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
-    TypedWhenCase, TypedWhenExpression,
+    TypedWhenCase, TypedWhenCaseName, TypedWhenExpression,
 };
 
 pub type ConcreteBinaryOperatorExpression = TypedBinaryOperatorExpression<ConcreteType>;
@@ -26,6 +26,7 @@ pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<Concre
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;
 pub type ConcreteWhenExpression = TypedWhenExpression<ConcreteType>;
 pub type ConcreteWhenCase = TypedWhenCase<ConcreteType>;
+pub type ConcreteWhenCaseName = TypedWhenCaseName;
 
 pub type ConcreteExpression = TypedExpression<ConcreteType>;
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -110,10 +110,16 @@ pub struct TypedUnaryOperatorExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypedWhenCaseName {
+    Name(String),
+    DefaultCase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedWhenCase<T> {
     pub expression_type: T,
     /// case_name == None indicates the default case
-    pub case_name: Option<TypedIdentifierExpression<T>>,
+    pub case_name: TypedWhenCaseName,
     pub case_arguments: Vec<TypedIdentifierExpression<T>>,
 }
 

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -118,9 +118,9 @@ pub enum TypedWhenCaseName {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedWhenCase<T> {
     pub expression_type: T,
-    /// case_name == None indicates the default case
     pub case_name: TypedWhenCaseName,
     pub case_arguments: Vec<TypedIdentifierExpression<T>>,
+    pub case_expression: TypedExpression<T>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/js/invalid/when/mismatched-types-0.buri
+++ b/tests/js/invalid/when/mismatched-types-0.buri
@@ -1,0 +1,4 @@
+x: #red | #green = #red
+result = when x is
+    #red do 1
+    #green do "hello"

--- a/tests/js/invalid/when/mismatched-types-1.buri
+++ b/tests/js/invalid/when/mismatched-types-1.buri
@@ -1,0 +1,4 @@
+x: #red | #green = #red
+result = when x is
+    #red do 1
+    _ do "hello"

--- a/tests/js/invalid/when/mismatched-types-2.buri
+++ b/tests/js/invalid/when/mismatched-types-2.buri
@@ -1,0 +1,3 @@
+blue = #blue
+result = when blue is
+    #red do 1

--- a/tests/js/invalid/when/mismatched-types-3.buri
+++ b/tests/js/invalid/when/mismatched-types-3.buri
@@ -1,0 +1,2 @@
+result = when #rgb(0, 0, 0) is
+    #rgb do 1

--- a/tests/js/invalid/when/mismatched-types-4.buri
+++ b/tests/js/invalid/when/mismatched-types-4.buri
@@ -1,0 +1,2 @@
+result = when #rgb(0, 0, 0) is
+    #rgb(red, green, blue) do red == "0"

--- a/tests/js/valid/when/definitions.buri
+++ b/tests/js/valid/when/definitions.buri
@@ -1,0 +1,15 @@
+Color = #red | #green | #blue
+
+@export
+colorToString = (color: Color) =>
+    when color is
+        #red do "red"
+        #green do "green"
+        #blue do "blue"
+
+Rgb = #rgb(Int, Int, Int)
+
+@export
+getRedComponent = (color: Rgb) =>
+    when color is
+        #rgb(r, g, b) do r

--- a/tests/js/valid/when/definitions.test.js
+++ b/tests/js/valid/when/definitions.test.js
@@ -1,0 +1,29 @@
+import {
+    BcolorToString,
+    BgetRedComponent,
+} from "@tests/js/valid/when/definitions.mjs"
+import { tag } from "../helpers"
+
+describe("colorToString", () => {
+    it('colorToString(#red) == "red"', () => {
+        expect(BcolorToString(tag("red"))).toEqual("red")
+    })
+
+    it('colorToString(#green) == "green"', () => {
+        expect(BcolorToString(tag("green"))).toEqual("green")
+    })
+
+    it('colorToString(#blue) == "blue"', () => {
+        expect(BcolorToString(tag("blue"))).toEqual("blue")
+    })
+})
+
+describe("getRedComponent", () => {
+    it("getRedComponent(#rgb(255, 0, 0)) == 255", () => {
+        expect(BgetRedComponent(tag("rgb", 255, 0, 0))).toEqual(255)
+    })
+
+    it("getRedComponent(#rgb(0, 255, 0)) == 0", () => {
+        expect(BgetRedComponent(tag("rgb", 0, 255, 0))).toEqual(0)
+    })
+})

--- a/tests/js/valid/when/type-checks.buri
+++ b/tests/js/valid/when/type-checks.buri
@@ -1,0 +1,12 @@
+color: #red | #rgb(Int, Int, Int) = #red
+result1 = when color is
+    #rgb(red, green, blue) do "custom color"
+    #red do "red"
+
+result2 = when #rgb(0, 0, 0) is
+    #rgb(red, green, blue) do 1
+
+blue: #red | #blue = #blue
+result3 = when blue is
+    #red do 1
+    _ do 2


### PR DESCRIPTION
There's almost definitely more e2e tests we can do. However we can add to them over time.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-380","parentHead":"5cd47026eb13abc5a8f813f0072b052c417dba75","parentPull":265,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-380","parentHead":"5cd47026eb13abc5a8f813f0072b052c417dba75","parentPull":265,"trunk":"main"}
```
-->
