### PR TITLE
Disable nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly
 
 on:
-  schedule:
-    - cron: "0 8 * * *" # 8am UTC, 12am PST
+  # schedule:
+  # - cron: "0 8 * * *" # 8am UTC, 12am PST
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Apparently the solution of replacing the nightly tag on GitHub will create an error every day you pull from main (because the local nightly tag differs from the origin nightly tag).

Disabling the automatic nightly builds so we don't get annoyed by that error message. We're planning to host the versions elsewhere anyways, so this is acceptable. I just commented out the code for now (for a quick fix). Will do a more thorough cleanup later this week.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
