### PR TITLE
Add getCharCode method to Buri string type

### DIFF
--- a/packages/std/prelude/string.js
+++ b/packages/std/prelude/string.js
@@ -1,3 +1,36 @@
+const isUtf16SurrogateAtIndex = (string, jsIndex) => (string.charCodeAt(jsIndex) & 0xF800) === 0xD800
+
+/**
+ * Assume that the string is valid UTF-16.
+ * Return the offset of the nth character in the string.
+ * If n is negative, return the offset of the character that is nth from the end.
+ * If the nth character is composed of a surrogate pair, return the offset of the high surrogate.
+ * If n is out of bounds, return -1.
+ */
+const jsIndexForNthCharacter = (string, n) => {
+    let step = n >= 0 ? 1 : -1
+    let characterIndex = n >= 0 ? 0 : -1
+    let jsIndex = n >= 0 ? 0 : string.length - 1
+
+    while (jsIndex >= 0 && jsIndex < string.length) {
+        if (characterIndex === n) {
+            if (step === -1 && isUtf16SurrogateAtIndex(string, jsIndex)) {
+                return jsIndex - 1
+            }
+            return jsIndex
+        } else {
+            characterIndex += step
+            if (isUtf16SurrogateAtIndex(string, jsIndex)) {
+                jsIndex += step * 2
+            } else {
+                jsIndex += step
+            }
+        }
+    }
+
+    return -1
+}
+
 Object.assign(String.prototype, {
     $clone() {
         return new this.constructor(this.valueOf())
@@ -5,5 +38,14 @@ Object.assign(String.prototype, {
 
     size() {
         return this.length
+    },
+
+    getCharCode(n) {
+        let jsIndex = jsIndexForNthCharacter(this, n)
+        if (jsIndex === -1) {
+            return ["none"]
+        } else {
+            return ["some", this.codePointAt(jsIndex)]
+        }
     },
 })

--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1230,7 +1230,7 @@ mod test {
     use parser::parse_test_expression;
     use typed_ast::ConcreteType;
 
-    const INITIAL_CONSTRAINT_COUNT: usize = 2;
+    const INITIAL_CONSTRAINT_COUNT: usize = 4;
 
     #[test]
     fn binary_operator_increments_id_counter_by_one_more_than_total_number_of_ids_in_children() {
@@ -1258,7 +1258,7 @@ mod test {
         translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
         assert_eq!(
             schema.get_total_canonical_ids(),
-            INITIAL_CONSTRAINT_COUNT + 15
+            INITIAL_CONSTRAINT_COUNT + 25
         );
     }
 
@@ -1318,7 +1318,7 @@ mod test {
         translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
         assert_eq!(
             schema.get_total_canonical_ids(),
-            INITIAL_CONSTRAINT_COUNT + 9
+            INITIAL_CONSTRAINT_COUNT + 11
         );
     }
 
@@ -1331,7 +1331,7 @@ mod test {
         translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
         assert_eq!(
             schema.get_total_canonical_ids(),
-            INITIAL_CONSTRAINT_COUNT + 9
+            INITIAL_CONSTRAINT_COUNT + 11
         );
     }
 
@@ -1767,7 +1767,7 @@ mod test {
         let mut schema = TypeSchema::new();
         let expression = parse_test_expression("\"hello\"");
         translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
-        assert_eq!(schema.count_ids(), INITIAL_CONSTRAINT_COUNT + 5);
+        assert_eq!(schema.count_ids(), INITIAL_CONSTRAINT_COUNT + 7);
     }
 
     #[test]
@@ -1777,7 +1777,7 @@ mod test {
         translate_parsed_expression_to_generic_expression(&mut schema, expression).unwrap();
         assert_eq!(
             schema.get_total_canonical_ids(),
-            INITIAL_CONSTRAINT_COUNT + 5
+            INITIAL_CONSTRAINT_COUNT + 7
         );
     }
 

--- a/rust/type_checker/types/src/default_types.rs
+++ b/rust/type_checker/types/src/default_types.rs
@@ -37,11 +37,18 @@ pub fn create_string_default_methods(
     schema: &mut TypeSchema,
 ) -> Result<(TypeId, Vec<HasMethodConstraint>), String> {
     create_parsed_constraint_from_methods(
-        vec![Method {
-            name: "size",
-            arguments: vec![],
-            return_type: INT_TYPE_ID,
-        }],
+        vec![
+            Method {
+                name: "size",
+                arguments: vec![],
+                return_type: INT_TYPE_ID,
+            },
+            Method {
+                name: "getCharCode",
+                arguments: vec![INT_TYPE_ID],
+                return_type: create_option_type(INT_TYPE_ID, schema)?,
+            },
+        ],
         schema,
     )
 }

--- a/tests/js/valid/strings/get-char-code.buri
+++ b/tests/js/valid/strings/get-char-code.buri
@@ -1,0 +1,19 @@
+hello = "hello"
+
+@export
+codeOfLowercaseH = hello:getCharCode(0)
+
+@export
+codeOfLowercaseE = hello:getCharCode(1)
+
+@export
+codeOfLowercaseO = hello:getCharCode(-1)
+
+@export
+codeOfLowercaseL = hello:getCharCode(-2)
+
+@export
+codeOfIndexBefore = hello:getCharCode(-50)
+
+@export
+codeOfIndexAfter = hello:getCharCode(50)

--- a/tests/js/valid/strings/get-char-code.test.js
+++ b/tests/js/valid/strings/get-char-code.test.js
@@ -1,0 +1,27 @@
+import { BcodeOfLowercaseH, BcodeOfLowercaseE, BcodeOfLowercaseO, BcodeOfLowercaseL, BcodeOfIndexBefore, BcodeOfIndexAfter } from "@tests/js/valid/strings/get-char-code.mjs"
+import { expect, it } from "bun:test"
+import { tag } from "../helpers"
+
+it("\"hello\":getCharCode(0) == #some(104)", () => {
+    expect(BcodeOfLowercaseH).toEqual(tag("some", 104))
+})
+
+it("\"hello\":getCharCode(1) == #some(101)", () => {
+    expect(BcodeOfLowercaseE).toEqual(tag("some", 101))
+})
+
+it("\"hello\":getCharCode(-1) == #some(111)", () => {
+    expect(BcodeOfLowercaseO).toEqual(tag("some", 111))
+})
+
+it("\"hello\":getCharCode(-2) == #some(108)", () => {
+    expect(BcodeOfLowercaseL).toEqual(tag("some", 108))
+})
+
+it("\"hello\":getCharCode(-1) == #none", () => {
+    expect(BcodeOfIndexBefore).toEqual(tag("none"))
+})
+
+it("\"hello\":getCharCode(50) == #none", () => {
+    expect(BcodeOfIndexAfter).toEqual(tag("none"))
+})


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"bootstrap-anatomy","parentHead":"8567ee1ca3d1d1f9a665a1514271aa03bc973712","parentPull":273,"trunk":"main"}
```
-->
