### PR TITLE
Modify size method on strings

### DIFF
--- a/packages/std/prelude/string.js
+++ b/packages/std/prelude/string.js
@@ -42,8 +42,16 @@ Object.assign(String.prototype, {
         return new this.constructor(this.valueOf())
     },
 
+    /// Assume that the string is valid UTF-16.
+    /// Return the number of characters in the string.
     size() {
-        return this.length
+        let characterCount = 0
+        let jsIndex = 0
+        while (jsIndex < this.length) {
+            characterCount += 1
+            jsIndex += 1 + ((this.charCodeAt(jsIndex) & 0xF800) === 0xD800)
+        }
+        return characterCount
     },
 
     getCharCode(n) {


### PR DESCRIPTION
Change the definition of the string `size` method so that it "just works" when Unicode support is added later.
Feel free to reject this PR on the grounds that it simply isn't important right now.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"parse-integer","parentHead":"ee3eb82f110c504f529cdbf038dd28af40a2b59f","parentPull":278,"trunk":"main"}
```
-->
