### PR TITLE
DO-NOT-MERGE-YET!  ::  Add stubbed type checker to MjolnirJS

### DIFF
--- a/buri/mjolnirjs/main.buri
+++ b/buri/mjolnirjs/main.buri
@@ -24,10 +24,38 @@ parseInteger = (string, index) =>
 
 parse = (input) =>
     when parseInteger(input, 0) is
-        #some(integer) do #ok(#parserDocument(#integer(integer)))
+        #some(integer) do #ok(#parserDocument({
+            typeDeclarations: [],
+            variableDeclarations: [#parserDeclaration({
+                name: "x",
+                value: #parserInteger(integer),
+                isExported: #false
+            })]
+        }))
         #none do #error("Unable to parse input")
 
-typeCheck = (input) => #ok(#genericDocument)
+typeCheckInteger = (integer) => #ok(#genericInteger(integer))
+
+typeCheckDeclaration = (declaration) =>
+    when declaration.value is
+        #parserInteger(integer) do when typeCheckInteger(integer) is
+            #ok(genericInteger) do #ok(#genericDeclaration({
+                name: declaration.name,
+                value: genericInteger,
+                isExported: declaration.isExported
+            }))
+
+loopTypeCheckDeclaration = (declarations, index, results) =>
+    when declarations:get(index) is
+        #some(declaration) do when typeCheckDeclaration(declaration) is
+            #ok(result) do loopTypeCheckDeclaration(declarations, index + 1, results:append(result))
+            #error(message) do #error(message)
+        #none do #ok(results)
+
+typeCheck = (parserDocument) =>
+    typeCheckedTypeDeclarations = []
+    typeCheckedVariableDeclarations = loopTypeCheckDeclaration(parserDocument.variableDeclarations, 0, [])
+    #ok(9)
 
 typeResolve = (input) => #ok(#concreteDocument)
 


### PR DESCRIPTION
The call to `loopTypeCheckDeclaration(parserDocument.variableDeclarations, 0, [])` produces a type error where a call to `loopTypeCheckDeclaration([], 0, [])` does not produce a type error. This may be circumvented by adding a `map` or `apply` method to the list type.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
