### PR TITLE
DO-NOT-MERGE-YET :: Add map and mapWithResult methods to list type

### DIFF
--- a/packages/std/prelude/list.js
+++ b/packages/std/prelude/list.js
@@ -25,4 +25,18 @@ Object.assign(Array.prototype, {
     size() {
         return this.length
     },
+
+    mapWithResult(func) {
+        let results = []
+        for (let i = 0; i < this.length; i++) {
+            let result = func(this[i])
+            if (result[0] === "error") {
+                return result
+            }
+            else {
+                results.push(result[1])
+            }
+        }
+        return ["ok", results]
+    }
 })


### PR DESCRIPTION
The function signatures for `map` and `mapWithResult` as they are given in `default_types.rs` are very likely flawed.
Careful thought is needed to design this well.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"unicode-string-length","parentHead":"f817d626ec6eca788e60a6f3936a64381c388175","parentPull":279,"trunk":"main"}
```
-->
