### PR TITLE
Improve compiler error ergonomics

### DIFF
--- a/rust/compiler/src/lib.rs
+++ b/rust/compiler/src/lib.rs
@@ -18,14 +18,7 @@ pub fn compile_buri_file(contents: &str) -> Result<String, String> {
             return Err(message);
         }
     };
-    let (generic_document, type_schema) = match apply_constraints(parsed_ast) {
-        Ok(items) => items,
-        Err(error) => {
-            let mut message = "Type Checking Error: ".to_owned();
-            message.push_str(error.as_str());
-            return Err(message);
-        }
-    };
+    let (generic_document, type_schema) = apply_constraints(parsed_ast)?;
     let concrete_document = resolve_concrete_types(type_schema, generic_document);
     Ok(print_js_document(&concrete_document))
 }

--- a/rust/mjolnirjs_spark/src/lib.rs
+++ b/rust/mjolnirjs_spark/src/lib.rs
@@ -17,12 +17,10 @@ fn stringify_path(path: &Path) -> Result<String, String> {
 /// Verify that a string encodes a valid file path with a specific extension.
 fn verify_path(path: &Path, required_extension: &str) -> Result<(), String> {
     match path.extension() {
-        None => {
-            return Err(format!(
-                "No extension provided for {}",
-                stringify_path(path)?
-            ))
-        }
+        None => Err(format!(
+            "No extension provided for {}",
+            stringify_path(path)?
+        )),
         Some(extension) => {
             if extension != OsStr::new(required_extension) {
                 return Err(format!(

--- a/rust/mjolnirjs_spark/src/main.rs
+++ b/rust/mjolnirjs_spark/src/main.rs
@@ -4,18 +4,18 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 
-fn main() -> Result<(), String> {
+fn main_impl() -> Result<(), String> {
     let arguments: Vec<String> = env::args().collect();
     let file_paths = get_file_paths(&arguments)?;
     let compiled_output = match std::fs::read_to_string(&file_paths.source) {
-        Ok(x) => compile_buri_file(&x),
+        Ok(x) => compile_buri_file(&x)?,
         Err(e) => {
             return Err(format!(
                 "Error reading source file {}: {e}",
                 file_paths.source
             ))
         }
-    }?;
+    };
     let mut output = match File::create(&file_paths.destination) {
         Ok(x) => x,
         Err(e) => {
@@ -35,4 +35,14 @@ fn main() -> Result<(), String> {
         }
     };
     Ok(())
+}
+
+fn main() -> Result<(), String> {
+    match main_impl() {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            println!("{e}");
+            Err(String::from("Could not compile Buri file"))
+        }
+    }
 }

--- a/rust/type_checker/errors/src/generate_backtrace_error.rs
+++ b/rust/type_checker/errors/src/generate_backtrace_error.rs
@@ -2,7 +2,12 @@ use backtrace::Backtrace;
 
 #[must_use]
 pub fn generate_backtrace_error(mut message: String) -> String {
-    message.push('\n');
-    message.push_str(&format!("{:?}", Backtrace::new()));
-    message
+    match std::env::var("BURI_BACKTRACE") {
+        Ok(value) if value == "1" => {
+            message.push('\n');
+            message.push_str(&format!("{:?}", Backtrace::new()));
+            message
+        }
+        _ => message,
+    }
 }

--- a/rust/type_checker/types/src/parsed_constraint.rs
+++ b/rust/type_checker/types/src/parsed_constraint.rs
@@ -252,7 +252,11 @@ impl CategoryConstraints {
             Self::TagGroup(tag_group) => match tag_group {
                 TagGroupConstraints::ClosedTags(tags) | TagGroupConstraints::OpenTags(tags) => {
                     tags.get(tag_name).map_or_else(
-                        || Err(format!("Tag {tag_name} not found")),
+                        || {
+                            Err(generate_backtrace_error(format!(
+                                "Tag #{tag_name} not found"
+                            )))
+                        },
                         |types| Ok(types.clone()),
                     )
                 }


### PR DESCRIPTION
While debugging the compilation issue in #278, I started doing little tweaks to improve error ergonomics that I figured I should pull them out into a PR.

- Simplify how we handle a few errors.
- Add backtrace when finding an invalid tag.
- Update `Tag some not found` errors to `Tag #some not found`.
- Hide backtrace behind an environment variable.

I added that last one because I noticed it was annoying to constantly scroll up to see the actual compiler error. I need the error message every time, but I don't need the backtrace every time. So now you can opt into getting the backtrace using an environment variable:

```bash
BURI_BACKTRACE=1 cargo run --bin mjolnirjs_spark my-program.buri
```

Admittedly this isn't the best design pattern in my opinion—CLI arguments would be better because they're more predictable when piping between programs (e.g., with Bazel). But using environment variables for this is very common and I didn't feel like adding a full CLI args parser just for this.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
