### PR TITLE
Ensure if expression true path is added to canonical type

### DIFF
--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -614,15 +614,15 @@ fn translate_if<'a>(
     schema.scope.start_sub_scope();
     let translated_false_path = if let Some(false_path) = node.value.path_if_false {
         schema.set_equal_to_canonical_type(
-            get_generic_type_id(&translated_true_path),
             type_id,
+            get_generic_type_id(&translated_true_path),
             &mut CheckedTypes::new(),
         )?;
         let translated_false_path =
             translate_parsed_expression_to_generic_expression(schema, *false_path)?;
         schema.set_equal_to_canonical_type(
-            get_generic_type_id(&translated_false_path),
             type_id,
+            get_generic_type_id(&translated_false_path),
             &mut CheckedTypes::new(),
         )?;
         Some(translated_false_path)

--- a/tests/js/valid/if/tag-unions-returns.buri
+++ b/tests/js/valid/if/tag-unions-returns.buri
@@ -1,0 +1,8 @@
+result = if #true do
+    #some(1)
+else
+    #none
+
+result2 = when result is
+    #some(num) do 1
+    #none do 2


### PR DESCRIPTION
Fixes the issue with compiling #278.

TLDR, the true branch type was never added to the overall type of the if expression. Therefore, an if where the true branch returns `#some(1)` and the false branch returns `#none` would always have a type of `#none`, not `#some(Int) | #none`.

This likely originated from when the schema method originally just set two types to be equal rather than setting the first as the canonical type of the second. So the type of the overall if expression was never updated.

I verified that the newly added Buri code in #278 successfully compiles with this fix (and without #277). I did not verify that the resulting JS output works as expected.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"error-ergonomics","parentHead":"36d511ebbff759d7669bf13acd23b979ba6ddbfc","parentPull":283,"trunk":"main"}
```
-->
