### PR TITLE
Test that the comment symbol is not an operator

### DIFF
--- a/rust/parser/src/block.rs
+++ b/rust/parser/src/block.rs
@@ -217,4 +217,13 @@ mod test {
         assert_eq!(remainder, "");
         assert_eq!(lines.value.len(), 2);
     }
+
+    #[test]
+    fn comment_can_appear_in_block() {
+        let input = ParserInput::new("    x = 1 + 1\n    -- this is a comment\n    x");
+        let result = block(ExpressionContext::new().increment_indentation())(input);
+        let (remainder, lines) = result.unwrap();
+        assert_eq!(remainder, "");
+        assert_eq!(lines.value.len(), 2);
+    }
 }

--- a/rust/parser/src/unary_operator.rs
+++ b/rust/parser/src/unary_operator.rs
@@ -9,7 +9,7 @@ use ast::{
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    combinator::{consumed, map, opt, verify},
+    combinator::{consumed, map, not, opt, peek, verify},
     sequence::preceded,
 };
 
@@ -49,7 +49,7 @@ pub fn unary_operator_expression(
             ),
             map(
                 preceded(
-                    tag("-"),
+                    preceded(tag("-"), not(peek(tag("-")))),
                     preceded(
                         opt(intra_expression_whitespace(context)),
                         basic_expression(context),
@@ -149,5 +149,15 @@ mod test {
         let (remainder, consumed) = result.unwrap();
         assert_eq!(remainder, "");
         assert!(matches!(consumed.value.symbol, UnaryOperatorSymbol::Not));
+    }
+
+    #[test]
+    fn comment_symbol_is_not_unary_operator() {
+        let input = ParserInput::new("--1");
+        let result = unary_operator_expression(
+            ExpressionContext::new().allow_newlines_in_expressions(),
+            input,
+        );
+        assert!(result.is_err());
     }
 }

--- a/tests/js/valid/comments/in-a-block.buri
+++ b/tests/js/valid/comments/in-a-block.buri
@@ -1,0 +1,4 @@
+hello = () =>
+    x = 1 + 1
+    -- this is a comment
+    x

--- a/tests/js/valid/comments/semantic-invariance.buri
+++ b/tests/js/valid/comments/semantic-invariance.buri
@@ -1,0 +1,5 @@
+@export
+a = 1
+
+@export
+b = 1 -- 2

--- a/tests/js/valid/comments/semantic-invariance.test.js
+++ b/tests/js/valid/comments/semantic-invariance.test.js
@@ -1,0 +1,6 @@
+import { Ba, Bb } from "@tests/js/valid/comments/semantic-invariance.mjs"
+import { expect, it } from "bun:test"
+
+it("The presence of a comment does not change the value of an expression", () => {
+    expect(Ba).toBe(Bb)
+})


### PR DESCRIPTION
Until now we've been parsing the comment symbol `--` as a sequence of binary and unary operators.

Somehow this didn't produce a bug until now.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
