### PR TITLE
Add Enum Type Definition to Parser (B-388)

### DIFF
--- a/rust/ast/src/nodes.rs
+++ b/rust/ast/src/nodes.rs
@@ -72,6 +72,17 @@ pub struct EnumLiteralValue<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumVariantTypeValue<'a> {
+    pub variant_name: String,
+    pub payload: Vec<TypeExpression<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumTypeValue<'a> {
+    pub variants: Vec<EnumVariantTypeNode<'a>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionValue<'a> {
     pub arguments: Vec<FunctionArgumentNode<'a>>,
     pub return_type: Option<TypeIdentifierNode<'a>>,
@@ -204,6 +215,8 @@ pub type BinaryOperatorNode<'a> = ParsedNode<'a, BinaryOperatorValue<'a>>;
 pub type BlockNode<'a> = ParsedNode<'a, Vec<Expression<'a>>>;
 pub type DocumentNode<'a> = ParsedNode<'a, DocumentValue<'a>>;
 pub type EnumLiteralNode<'a> = ParsedNode<'a, EnumLiteralValue<'a>>;
+pub type EnumVariantTypeNode<'a> = ParsedNode<'a, EnumVariantTypeValue<'a>>;
+pub type EnumTypeNode<'a> = ParsedNode<'a, EnumTypeValue<'a>>;
 pub type FunctionNode<'a> = ParsedNode<'a, FunctionValue<'a>>;
 pub type FunctionApplicationArgumentsNode<'a> =
     ParsedNode<'a, FunctionApplicationArgumentsValue<'a>>;
@@ -253,6 +266,7 @@ pub enum Expression<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeExpression<'a> {
+    Enum(EnumTypeNode<'a>),
     Function(FunctionTypeNode<'a>),
     Identifier(TypeIdentifierNode<'a>),
     List(Box<ListTypeNode<'a>>),

--- a/rust/parser/src/enum_literal.rs
+++ b/rust/parser/src/enum_literal.rs
@@ -11,7 +11,7 @@ use nom::{
     sequence::{delimited, tuple},
 };
 
-fn variant_name(input: ParserInput) -> IResult<ParserInput> {
+pub fn variant_name(input: ParserInput) -> IResult<ParserInput> {
     verify(
         recognize(take_while1(|character: char| {
             character.is_ascii_alphanumeric() || character == '_'

--- a/rust/parser/src/enum_type.rs
+++ b/rust/parser/src/enum_type.rs
@@ -1,0 +1,252 @@
+use crate::{
+    enum_literal::variant_name, intra_expression_whitespace::intra_expression_whitespace,
+    type_expression::type_expression, ExpressionContext,
+};
+use ast::{
+    EnumTypeNode, EnumTypeValue, EnumVariantTypeNode, EnumVariantTypeValue, IResult, ParserInput,
+    TypeExpression,
+};
+
+use nom::{
+    bytes::complete::tag,
+    combinator::{consumed, map, opt, verify},
+    multi::separated_list1,
+    sequence::{delimited, tuple},
+};
+
+fn payload<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, Vec<TypeExpression>> {
+    delimited(
+        tuple((
+            opt(intra_expression_whitespace(context)),
+            tag("("),
+            opt(intra_expression_whitespace(
+                context.allow_newlines_in_expressions(),
+            )),
+        )),
+        separated_list1(
+            tuple((
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+                tag(","),
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+            )),
+            verify(type_expression, |type_expression| {
+                !matches!(type_expression, TypeExpression::Enum(_))
+            }),
+        ),
+        tuple((
+            opt(intra_expression_whitespace(
+                context.allow_newlines_in_expressions(),
+            )),
+            opt(tag(",")),
+            opt(intra_expression_whitespace(
+                context.allow_newlines_in_expressions(),
+            )),
+            tag(")"),
+        )),
+    )
+}
+
+fn enum_variant<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, EnumVariantTypeNode<'a>> {
+    move |input| {
+        map(
+            consumed(tuple((tag("."), variant_name, opt(payload(context))))),
+            |(input, (_, name, payload))| EnumVariantTypeNode {
+                source: input,
+                value: EnumVariantTypeValue {
+                    variant_name: name.value().to_owned(),
+                    payload: payload.map_or_else(Vec::new, |payload| payload),
+                },
+            },
+        )(input)
+    }
+}
+
+pub fn enum_type<'a>(
+    context: ExpressionContext,
+) -> impl FnMut(ParserInput<'a>) -> IResult<'a, EnumTypeNode<'a>> {
+    map(
+        consumed(separated_list1(
+            tuple((
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+                tag("|"),
+                opt(intra_expression_whitespace(
+                    context.allow_newlines_in_expressions(),
+                )),
+            )),
+            enum_variant(context),
+        )),
+        |(input, variants)| EnumTypeNode {
+            source: input,
+            value: EnumTypeValue { variants },
+        },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_input_is_not_an_enum_type() {
+        let input = ParserInput::new("");
+        let result = enum_type(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn identifier_is_not_an_enum_type() {
+        let input = ParserInput::new("a");
+        let result = enum_type(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn period_is_not_an_enum_type() {
+        let input = ParserInput::new(".");
+        let result = enum_type(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn period_followed_by_identifier_is_enum_type() {
+        let input = ParserInput::new(".a");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn identifier_followed_by_a_period_is_not_an_enum_type() {
+        let input = ParserInput::new("a.");
+        let result = enum_type(ExpressionContext::new())(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn variant_name_is_preserved() {
+        let input = ParserInput::new(".a");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (_, node) = result.unwrap();
+        assert_eq!(node.value.variants.get(0).unwrap().value.variant_name, "a");
+    }
+
+    #[test]
+    fn empty_payload_stops_parsing_before_payload() {
+        let input = ParserInput::new(".a()");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "()");
+    }
+
+    #[test]
+    fn empty_payload_with_comma_stops_parsing_before_payload() {
+        let input = ParserInput::new(".a(,)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "(,)");
+    }
+
+    #[test]
+    fn one_payload_parses() {
+        let input = ParserInput::new(".a(Int)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn two_payloads_parse() {
+        let input = ParserInput::new(".a(Int,Int)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn can_have_trailing_comma_with_one_payload() {
+        let input = ParserInput::new(".a(Int,)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn can_have_trailing_comma_with_two_payloads() {
+        let input = ParserInput::new(".a(Int,Int,)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn can_have_spaces_within_payload() {
+        let input = ParserInput::new(".a(   Int   ,   Int   )");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn can_have_newlines_within_payload() {
+        let input = ParserInput::new(".a(\nInt\n,\nInt\n)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn payload_value_is_preserved() {
+        let input = ParserInput::new(".a(Int)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (_, node) = result.unwrap();
+        match node
+            .value
+            .variants
+            .get(0)
+            .unwrap()
+            .value
+            .payload
+            .get(0)
+            .unwrap()
+        {
+            TypeExpression::Identifier(identifier_node) => {
+                assert_eq!(identifier_node.value, "Int");
+            }
+            _ => panic!("Payload value not preserved"),
+        };
+    }
+
+    #[test]
+    fn can_have_two_variants() {
+        let input = ParserInput::new(".a | .b");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn can_have_two_variants_without_spaces() {
+        let input = ParserInput::new(".a|.b");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn enum_payload_stops_parsing_before_payload() {
+        let input = ParserInput::new(".a(.b)");
+        let result = enum_type(ExpressionContext::new())(input);
+        let (remainder, _) = result.unwrap();
+        assert_eq!(remainder, "(.b)");
+    }
+}

--- a/rust/parser/src/lib.rs
+++ b/rust/parser/src/lib.rs
@@ -4,6 +4,7 @@ mod binary_operator_or_if;
 mod block;
 mod document;
 mod enum_literal;
+mod enum_type;
 mod expression_context;
 mod file;
 mod function;

--- a/rust/parser/src/type_expression.rs
+++ b/rust/parser/src/type_expression.rs
@@ -1,7 +1,8 @@
+use crate::enum_type::enum_type;
 use crate::tag_group_type::tag_group_type;
 use crate::{
     function_type::function_type, list_type::list_type, record_type::record_type,
-    type_identifier::type_identifier,
+    type_identifier::type_identifier, ExpressionContext,
 };
 use ast::TypeExpression;
 use ast::{IResult, ParserInput};
@@ -11,6 +12,7 @@ pub fn type_expression(input: ParserInput) -> IResult<TypeExpression> {
     alt((
         map(type_identifier, TypeExpression::Identifier),
         map(list_type, |list| TypeExpression::List(Box::new(list))),
+        map(enum_type(ExpressionContext::new()), TypeExpression::Enum),
         map(tag_group_type, TypeExpression::TagGroup),
         map(record_type, TypeExpression::Record),
         map(function_type, TypeExpression::Function),

--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1043,6 +1043,7 @@ fn translate_parsed_type_expression(
     expression: &TypeExpression,
 ) -> Result<TypeId, String> {
     match expression {
+        TypeExpression::Enum(_) => unimplemented!("Enum types are not yet supported"),
         TypeExpression::Function(function) => translate_function_type(schema, function),
         TypeExpression::Identifier(identifier) => {
             translate_type_identifier_type(schema, identifier)


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"parse-enum-literal","parentHead":"d078ebe5c290cfda425e46ccf8dc029d65919045","parentPull":286,"trunk":"main"}
```
-->
