### PR TITLE
Add enum types to type checker

### DIFF
--- a/rust/js_backend/src/expression/mod.rs
+++ b/rust/js_backend/src/expression/mod.rs
@@ -41,6 +41,9 @@ fn print_expression(expression: &ConcreteExpression) -> String {
             unary_operator::print_unary_operator(operator)
         }
         ConcreteExpression::Tag(tag) => tag::print_tag(tag),
+        ConcreteExpression::Enum(_) => {
+            unimplemented!("Unable to print enum expression")
+        }
         ConcreteExpression::If(if_expression) => if_expression::print_if_expression(if_expression),
         ConcreteExpression::Block(block) => block::print_block(block),
         ConcreteExpression::Function(function) => {

--- a/rust/type_checker/types/src/constraints.rs
+++ b/rust/type_checker/types/src/constraints.rs
@@ -3,6 +3,15 @@ use std::collections::HashMap;
 use typed_ast::PrimitiveType;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Constrain that a generic type is an enum with a specific
+/// set of variants, each of which has a specific set of types.
+pub struct EnumConstraint {
+    /// The keys are the names of the variants in the enum.
+    /// The values are the types of the variant payloads.
+    pub variants: HashMap<String, Vec<TypeId>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Constrain that a generic type is a tag union
 /// with a tag of given name whose payload has particular types.
 pub struct HasTagConstraint {
@@ -52,6 +61,8 @@ pub enum Constraint {
     EqualToPrimitive(PrimitiveType),
     /// Constrain that a generic type is a list whose contents have a particular type.
     ListOfType(TypeId),
+    /// Constrain that a generic type is an enum with a given set of variants.
+    Enum(EnumConstraint),
     /// Constrain that a generic type is a tag union with at least a given set of tags.
     HasTag(HasTagConstraint),
     /// Constrain that a generic type is a tag union with at most a given set of tags.

--- a/rust/type_checker/types/src/generic_nodes.rs
+++ b/rust/type_checker/types/src/generic_nodes.rs
@@ -2,7 +2,7 @@ use crate::TypeId;
 use ast::{ImportNode, ParserInput, TopLevelDeclaration};
 use typed_ast::{
     TypedBinaryOperatorExpression, TypedBlockExpression, TypedBooleanLiteralExpression,
-    TypedDeclarationExpression, TypedExpression, TypedFunctionExpression,
+    TypedDeclarationExpression, TypedEnumExpression, TypedExpression, TypedFunctionExpression,
     TypedIdentifierExpression, TypedIfExpression, TypedIntegerLiteralExpression,
     TypedListExpression, TypedRecordAssignmentExpression, TypedRecordExpression,
     TypedStringLiteralExpression, TypedTagExpression, TypedTypeDeclarationExpression,
@@ -34,6 +34,7 @@ pub type GenericRecordAssignmentExpression<'a> =
 pub type GenericRecordExpression<'a> = TypedRecordExpression<GenericSourcedType<'a>>;
 pub type GenericStringLiteralExpression<'a> = TypedStringLiteralExpression<GenericSourcedType<'a>>;
 pub type GenericTagExpression<'a> = TypedTagExpression<GenericSourcedType<'a>>;
+pub type GenericEnumExpression<'a> = TypedEnumExpression<GenericSourcedType<'a>>;
 pub type GenericTypeDeclarationExpression<'a> =
     TypedTypeDeclarationExpression<GenericSourcedType<'a>>;
 pub type GenericTypeIdentifierExpression<'a> =
@@ -71,6 +72,7 @@ pub const fn get_generic_type_id(input: &GenericExpression) -> TypeId {
         GenericExpression::RecordAssignment(node) => node.expression_type.type_id,
         GenericExpression::StringLiteral(node) => node.expression_type.type_id,
         GenericExpression::Tag(node) => node.expression_type.type_id,
+        GenericExpression::Enum(node) => node.expression_type.type_id,
         GenericExpression::TypeDeclaration(node) => node.expression_type.type_id,
         GenericExpression::TypeIdentifier(node) => node.expression_type.type_id,
         GenericExpression::UnaryOperator(node) => node.expression_type.type_id,

--- a/rust/typed_ast/src/concrete_nodes.rs
+++ b/rust/typed_ast/src/concrete_nodes.rs
@@ -1,7 +1,7 @@
 use crate::{
     ConcreteType, TypedBinaryOperatorExpression, TypedBlockExpression,
-    TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedDocument, TypedExpression,
-    TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
+    TypedBooleanLiteralExpression, TypedDeclarationExpression, TypedDocument, TypedEnumExpression,
+    TypedExpression, TypedFunctionExpression, TypedIdentifierExpression, TypedIfExpression,
     TypedIntegerLiteralExpression, TypedListExpression, TypedRecordAssignmentExpression,
     TypedRecordExpression, TypedStringLiteralExpression, TypedTagExpression,
     TypedTypeDeclarationExpression, TypedTypeIdentifierExpression, TypedUnaryOperatorExpression,
@@ -21,6 +21,7 @@ pub type ConcreteRecordExpression = TypedRecordExpression<ConcreteType>;
 pub type ConcreteRecordAssignmentExpression = TypedRecordAssignmentExpression<ConcreteType>;
 pub type ConcreteStringLiteralExpression = TypedStringLiteralExpression<ConcreteType>;
 pub type ConcreteTagExpression = TypedTagExpression<ConcreteType>;
+pub type ConcreteEnumExpression = TypedEnumExpression<ConcreteType>;
 pub type ConcreteTypeDeclarationExpression = TypedTypeDeclarationExpression<ConcreteType>;
 pub type ConcreteTypeIdentifierExpression = TypedTypeIdentifierExpression<ConcreteType>;
 pub type ConcreteUnaryOperatorExpression = TypedUnaryOperatorExpression<ConcreteType>;

--- a/rust/typed_ast/src/concrete_types.rs
+++ b/rust/typed_ast/src/concrete_types.rs
@@ -24,6 +24,12 @@ pub struct ConcreteTagUnionType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteEnumType {
+    /// Map the name of a variant to an array of the types of its payload types.
+    pub variants: HashMap<String, Vec<ConcreteType>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConcreteListType {
     pub element_type: ConcreteType,
 }
@@ -39,6 +45,7 @@ pub enum ConcreteType {
     Primitive(PrimitiveType),
     Function(Box<ConcreteFunctionType>),
     TagUnion(Box<ConcreteTagUnionType>),
+    Enum(Box<ConcreteEnumType>),
     List(Box<ConcreteListType>),
     Record(Box<ConcreteRecordType>),
 }

--- a/rust/typed_ast/src/nodes.rs
+++ b/rust/typed_ast/src/nodes.rs
@@ -90,6 +90,13 @@ pub struct TypedTagExpression<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedEnumExpression<T> {
+    pub expression_type: T,
+    pub name: String,
+    pub contents: Vec<TypedExpression<T>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypedTypeDeclarationExpression<T> {
     pub declaration_type: T,
     pub expression_type: T,
@@ -146,6 +153,7 @@ pub enum TypedExpression<T> {
     RecordAssignment(Box<TypedRecordAssignmentExpression<T>>),
     StringLiteral(Box<TypedStringLiteralExpression<T>>),
     Tag(Box<TypedTagExpression<T>>),
+    Enum(Box<TypedEnumExpression<T>>),
     TypeDeclaration(Box<TypedTypeDeclarationExpression<T>>),
     TypeIdentifier(Box<TypedTypeIdentifierExpression<T>>),
     UnaryOperator(Box<TypedUnaryOperatorExpression<T>>),


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"restrict_to_ascii","parentHead":"56cec042bb4f7cbedb691df316b678b11f0316f8","parentPull":288,"trunk":"main"}
```
-->
