### PR TITLE
Add global Bool type

### DIFF
--- a/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
+++ b/rust/type_checker/translator/src/parsed_expression_to_generic_expression.rs
@@ -1307,7 +1307,7 @@ mod test {
     use parser::parse_test_expression;
     use typed_ast::ConcreteType;
 
-    const INITIAL_CONSTRAINT_COUNT: usize = 4;
+    const INITIAL_CONSTRAINT_COUNT: usize = 5;
 
     #[test]
     fn binary_operator_increments_id_counter_by_one_more_than_total_number_of_ids_in_children() {

--- a/rust/type_checker/types/src/type_schema.rs
+++ b/rust/type_checker/types/src/type_schema.rs
@@ -1,5 +1,5 @@
 use crate::{
-    constraints::{Constraint, HasMethodConstraint},
+    constraints::{Constraint, EnumExactConstraint, HasMethodConstraint},
     parsed_constraint::ParsedConstraint,
     scope::Scope,
     type_checking_call_stack::CheckedTypes,
@@ -87,6 +87,18 @@ impl TypeSchema {
             .declare_identifier_with_constraint(
                 String::from("Str"),
                 Constraint::EqualToPrimitive(PrimitiveType::Str),
+                &mut CheckedTypes::new(),
+            )
+            .unwrap();
+        schema
+            .declare_identifier_with_constraint(
+                String::from("Bool"),
+                Constraint::EnumExact(EnumExactConstraint {
+                    variants: HashMap::from([
+                        (String::from("true"), Vec::new()),
+                        (String::from("false"), Vec::new()),
+                    ]),
+                }),
                 &mut CheckedTypes::new(),
             )
             .unwrap();

--- a/tests/js/valid/enum/declaration.buri
+++ b/tests/js/valid/enum/declaration.buri
@@ -1,3 +1,9 @@
+@export
+booleanTrue = Bool.true
+
+@export
+booleanFalse = Bool.false
+
 Hello = .hello
 
 @export


### PR DESCRIPTION
Tests to show these are compiled to `true` and `false` coming in a follow-up PR.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-397","parentHead":"6242e43bfdf90f175f9c6e48d259d86e4a75d584","parentPull":296,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-397","parentHead":"6242e43bfdf90f175f9c6e48d259d86e4a75d584","parentPull":296,"trunk":"main"}
```
-->
