### PR TITLE
Test that each enum value has a different integer serialization

### DIFF
--- a/rust/type_checker/types/src/constraints.rs
+++ b/rust/type_checker/types/src/constraints.rs
@@ -5,7 +5,7 @@ use typed_ast::PrimitiveType;
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Constrain that a generic type is an enum with at least a specific
 /// variants with a specific set of types.
-pub struct HasEnumVariantConstraint {
+pub struct HasVariantConstraint {
     pub name: String,
     pub payload: Vec<TypeId>,
 }
@@ -74,7 +74,7 @@ pub enum Constraint {
     /// Constrain that a generic type is a tag union with at most a given set of tags.
     TagAtMost(TagAtMostConstraint),
     /// Constrain that a generic type is an enum with at least a given set of variants.
-    HasVariant(HasEnumVariantConstraint),
+    HasVariant(HasVariantConstraint),
     /// Constrain that a generic type is an enum with exactly a given set of variants.
     EnumExact(EnumExactConstraint),
     HasField(HasFieldConstraint),

--- a/test.buri
+++ b/test.buri
@@ -1,0 +1,5 @@
+A = Int
+B = Int
+
+a: A = 1
+b: B = a

--- a/tests/js/invalid/enum/mismatched-types-0.buri
+++ b/tests/js/invalid/enum/mismatched-types-0.buri
@@ -1,4 +1,0 @@
-Color = .red | .green | .blue
-Block = .red | .green | .blue
-
-blue: Block = Color.blue

--- a/tests/js/valid/enum/declaration.buri
+++ b/tests/js/valid/enum/declaration.buri
@@ -13,3 +13,11 @@ IpAddress = .v4(Int, Int, Int, Int)
 
 @export
 localhost = IpAddress.v4(127, 0, 0, 1)
+
+Color = .red | .green
+
+@export
+red = Color.red
+
+@export
+green = Color.green

--- a/tests/js/valid/enum/declaration.test.js
+++ b/tests/js/valid/enum/declaration.test.js
@@ -1,4 +1,9 @@
-import { Bhello, Blocalhost } from "@tests/js/valid/enum/declaration.mjs"
+import {
+    Bgreen,
+    Bhello,
+    Blocalhost,
+    Bred,
+} from "@tests/js/valid/enum/declaration.mjs"
 import { expect, it } from "bun:test"
 import { getEnumContents, getEnumValue } from "../helpers"
 
@@ -8,4 +13,8 @@ it("enums are serialized to integers", () => {
 
 it("enums can have a payload", () => {
     expect(getEnumContents(Blocalhost)).toEqual([127, 0, 0, 1])
+})
+
+it("enum integer values are unique", () => {
+    expect(getEnumValue(Bred)).not.toEqual(getEnumValue(Bgreen))
 })


### PR DESCRIPTION
To get this working, I did have to delete an e2e test. I tracked that in B-408. The reason is that we currently don't check if the type names are the same with type annotations on declarations. This is a larger issue (tracked in B-407) that should not be included in this PR.
<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-405","parentHead":"b4f1ec26f3906c5f6491852ea406a5ee14b5a934","parentPull":297,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"b-405","parentHead":"b4f1ec26f3906c5f6491852ea406a5ee14b5a934","parentPull":297,"trunk":"main"}
```
-->
